### PR TITLE
feat: Include the date when composing the prompt.

### DIFF
--- a/Source/Service/PromptService.cs
+++ b/Source/Service/PromptService.cs
@@ -229,6 +229,9 @@ namespace RimTalk.Service
             // add time
             prompt += $"\nTime: {CommonUtil.GetInGameHour12HString()}";
             
+            // add date
+            prompt += $"\nDate: {CommonUtil.GetInGameDateString()}";
+            
             // add pawn names
             prompt = pawn1.Name.ToStringShort + (pawn2 != null ? $" and {pawn2.Name.ToStringShort}" : "") + ": " + prompt;
 

--- a/Source/Util/CommonUtil.cs
+++ b/Source/Util/CommonUtil.cs
@@ -63,6 +63,22 @@ namespace RimTalk.Util
             return $"{hour12}{ampm}";
         }
         
+        // Returns the year, quarter, and day.
+        public static string GetInGameDateString()
+        {
+            try
+            {
+                if (Find.CurrentMap?.Tile == null)
+                    return "N/A";
+                
+                return GenDate.DateFullStringAt(Find.TickManager.TicksAbs, Find.WorldGrid.LongLatOf(Find.CurrentMap.Tile));
+            }
+            catch (Exception)
+            {
+                return "N/A";
+            }
+        }
+        
         // Simple token estimation algorithm (approximate)
         public static int EstimateTokenCount(string text)
         {


### PR DESCRIPTION
### Overview:
I enjoy documenting the colony's historical and upcoming events with dates in the prompt. I implemented this feature because I believe that including the current date in the API request will generate more dynamic dialogue, such as reminiscing about the past or worrying about future events.

### Changes:
Added a GetInGameDateString() method to the CommonUtil class that returns the current in-game date.

In PromptService, this method is called to include the date information when generating the AI prompt.

### Considerations:
Given that a RimWorld year has 60 days (4 quadrums, 15 days per quadrum), adding a simple explanation to the base prompt (e.g., "A year has 4 quadrums, and a quadrum has 15 days.") might help the AI use the date information more accurately.

However, I excluded this from the current change to avoid making the prompt too long. I would appreciate it if you would consider this as just an idea.