### PR TITLE
feat: Research job detection for Research Reinvented compatibility

### DIFF
--- a/Source/Service/PawnService.cs
+++ b/Source/Service/PawnService.cs
@@ -257,14 +257,27 @@ namespace RimTalk.Service
             return closestPawn;
         }
         
+        // Using a HashSet for better readability and maintainability.
+        private static readonly HashSet<string> ResearchJobDefNames = new HashSet<string>
+        {
+            "Research",                 
+            // MOD: Research Reinvented
+            "RR_Analyse",               
+            "RR_AnalyseInPlace",
+            "RR_AnalyseTerrain",
+            "RR_Research",
+            "RR_InterrogatePrisoner",
+            "RR_LearnRemotely"
+        };
+        
         public static string GetStatus(Pawn pawn)
         {
             pawn.def.hideMainDesc = true;
             string status = pawn.GetInspectString();
-            if (pawn.CurJob?.def == JobDefOf.Research)
+            if (ResearchJobDefNames.Contains(pawn.CurJob?.def.defName)) // The job is compared against its defined name.
             {
                 ResearchProjectDef project = Find.ResearchManager.GetProject();
-                status += $" ({project.label})";
+                status += $" (Project: {project.label})"; // Adding 'Project:' seems to work better for dialogue generation!
             }
             return status;
         }


### PR DESCRIPTION
### Problem:
The current logic for adding research project information to the AI prompt only checks for the vanilla JobDef ("Research").

This causes an incompatibility with the popular mod 'Research Reinvented,' which adds multiple custom research jobs like RR_Analyse and RR_Research. As a result, when this mod is used, the current project is not included in the prompt even when a pawn is actively researching.

### Solution:
The method for detecting research jobs has been changed to compare against a list of compatible defNames instead of a single, specific one. This provides better mod compatibility and scalability.

### Changes:
**HashSet<string> Implementation:** A ResearchJobDefNames HashSet<string> was added to PawnService to manage the defNames of various research jobs. This makes it easy to check the list of compatible jobs and simplifies support for other mods in the future.

**Conditional Logic Change:** The existing if statement was modified to check if the current job's defName is included in the HashSet.

// Before:
if (pawn.CurJob?.def == JobDefOf.Research)
// After:
if (ResearchJobDefNames.Contains(pawn.CurJob?.def.defName))

**Improved Prompt Clarity:** When adding research project information to the AI prompt, the prefix "Project: " was added before project.label to improve clarity. This helps generate more fitting dialogue.