### PR TITLE
fix: Add "Allow Babies To Talk" setting

### DIFF
--- a/Languages/ChineseSimplified/Keyed/RimTalk.xml
+++ b/Languages/ChineseSimplified/Keyed/RimTalk.xml
@@ -91,6 +91,8 @@
     <RimTalk.Settings.AllowOtherFactionsToTalkTooltip>启用此项以允许其他派系成员进行 AI 生成的对话。</RimTalk.Settings.AllowOtherFactionsToTalkTooltip>
     <RimTalk.Settings.AllowEnemiesToTalk>允许敌人交谈</RimTalk.Settings.AllowEnemiesToTalk>
     <RimTalk.Settings.AllowEnemiesToTalkTooltip>启用此项以允许敌人进行 AI 生成的对话。</RimTalk.Settings.AllowEnemiesToTalkTooltip>
+    <RimTalk.Settings.AllowEnemiesToTalk>允许婴幼儿交谈</RimTalk.Settings.AllowEnemiesToTalk>
+    <RimTalk.Settings.AllowEnemiesToTalkTooltip>启用此项以允许婴幼儿进行 AI 生成的对话。</RimTalk.Settings.AllowEnemiesToTalkTooltip>
     <RimTalk.Settings.PauseAtSpeed>高速时暂停 AI</RimTalk.Settings.PauseAtSpeed>
     <RimTalk.Settings.DisableAiAtSpeedTooltip>为减少 API 调用，当游戏速度设置为此级别或更高级别时，AI 将暂停。</RimTalk.Settings.DisableAiAtSpeedTooltip>
     <RimTalk.Settings.Disabled>已禁用</RimTalk.Settings.Disabled>

--- a/Languages/ChineseTraditional/Keyed/RimTalk.xml
+++ b/Languages/ChineseTraditional/Keyed/RimTalk.xml
@@ -91,6 +91,8 @@
     <RimTalk.Settings.AllowOtherFactionsToTalkTooltip>啟用此項以允許其他派系成員進行 AI 生成的對話。</RimTalk.Settings.AllowOtherFactionsToTalkTooltip>
     <RimTalk.Settings.AllowEnemiesToTalk>允許敵人交談</RimTalk.Settings.AllowEnemiesToTalk>
     <RimTalk.Settings.AllowEnemiesToTalkTooltip>啟用此項以允許敵人進行 AI 生成的對話。</RimTalk.Settings.AllowEnemiesToTalkTooltip>
+    <RimTalk.Settings.AllowEnemiesToTalk>允許嬰兒交談</RimTalk.Settings.AllowEnemiesToTalk>
+    <RimTalk.Settings.AllowEnemiesToTalkTooltip>啟用此項以允許嬰兒進行 AI 生成的對話。</RimTalk.Settings.AllowEnemiesToTalkTooltip>
     <RimTalk.Settings.PauseAtSpeed>高速時暫停 AI</RimTalk.Settings.PauseAtSpeed>
     <RimTalk.Settings.DisableAiAtSpeedTooltip>為減少 API 呼叫，當遊戲速度設定為此級別或更高級別時，AI 將暫停。</RimTalk.Settings.DisableAiAtSpeedTooltip>
     <RimTalk.Settings.Disabled>已禁用</RimTalk.Settings.Disabled>

--- a/Languages/English/Keyed/RimTalk.xml
+++ b/Languages/English/Keyed/RimTalk.xml
@@ -91,6 +91,8 @@
     <RimTalk.Settings.AllowOtherFactionsToTalkTooltip>Enable this to allow members of other factions to have AI-generated conversations.</RimTalk.Settings.AllowOtherFactionsToTalkTooltip>
     <RimTalk.Settings.AllowEnemiesToTalk>Allow Enemies to Talk</RimTalk.Settings.AllowEnemiesToTalk>
     <RimTalk.Settings.AllowEnemiesToTalkTooltip>Enable this to allow enemies to have AI-generated conversations.</RimTalk.Settings.AllowEnemiesToTalkTooltip>
+    <RimTalk.Settings.AllowBabiesToTalk>Allow infants and toddlers to talk</RimTalk.Settings.AllowBabiesToTalk>
+    <RimTalk.Settings.AllowBabiesToTalkTooltip>Enable this option to allow infants and toddlers to participate in AI-generated conversations.</RimTalk.Settings.AllowBabiesToTalkTooltip>
     <RimTalk.Settings.PauseAtSpeed>Pause AI on High Speed</RimTalk.Settings.PauseAtSpeed>
     <RimTalk.Settings.DisableAiAtSpeedTooltip>To reduce API calls, the AI will be paused when game speed is set to this level or higher.</RimTalk.Settings.DisableAiAtSpeedTooltip>
     <RimTalk.Settings.Disabled>Disabled</RimTalk.Settings.Disabled>

--- a/Languages/French/Keyed/RimTalk.xml
+++ b/Languages/French/Keyed/RimTalk.xml
@@ -91,6 +91,8 @@
     <RimTalk.Settings.AllowOtherFactionsToTalkTooltip>Activez ceci pour permettre aux membres d'autres factions d'avoir des conversations générées par l'IA.</RimTalk.Settings.AllowOtherFactionsToTalkTooltip>
     <RimTalk.Settings.AllowEnemiesToTalk>Autoriser les ennemis à parler</RimTalk.Settings.AllowEnemiesToTalk>
     <RimTalk.Settings.AllowEnemiesToTalkTooltip>Activez ceci pour permettre aux ennemis d'avoir des conversations générées par l'IA.</RimTalk.Settings.AllowEnemiesToTalkTooltip>
+    <RimTalk.Settings.AllowBabiesToTalk>Autoriser les nourrissons et les tout-petits à parler</RimTalk.Settings.AllowBabiesToTalk>
+    <RimTalk.Settings.AllowBabiesToTalkTooltip>Activez ceci pour permettre aux nourrissons et aux tout-petits des conversations générées par l'IA.</RimTalk.Settings.AllowBabiesToTalkTooltip>
     <RimTalk.Settings.PauseAtSpeed>Mettre l'IA en pause à haute vitesse</RimTalk.Settings.PauseAtSpeed>
     <RimTalk.Settings.DisableAiAtSpeedTooltip>Pour réduire les appels à l'API, l'IA sera mise en pause lorsque la vitesse du jeu est réglée sur ce niveau ou plus.</RimTalk.Settings.DisableAiAtSpeedTooltip>
     <RimTalk.Settings.Disabled>Désactivé</RimTalk.Settings.Disabled>

--- a/Languages/Japanese/Keyed/RimTalk.xml
+++ b/Languages/Japanese/Keyed/RimTalk.xml
@@ -91,6 +91,8 @@
     <RimTalk.Settings.AllowOtherFactionsToTalkTooltip>これを有効にすると、他派閥のメンバーがAI生成の会話を行えるようになります。</RimTalk.Settings.AllowOtherFactionsToTalkTooltip>
     <RimTalk.Settings.AllowEnemiesToTalk>敵の会話を許可</RimTalk.Settings.AllowEnemiesToTalk>
     <RimTalk.Settings.AllowEnemiesToTalkTooltip>これを有効にすると、敵がAI生成の会話を行えるようになります。</RimTalk.Settings.AllowEnemiesToTalkTooltip>
+    <RimTalk.Settings.AllowBabiesToTalk>乳児と幼児の会話を許可</RimTalk.Settings.AllowBabiesToTalk>
+    <RimTalk.Settings.AllowBabiesToTalkTooltip>これを有効にすると、乳児や幼児がAI生成の会話を行えるようになります。</RimTalk.Settings.AllowBabiesToTalkTooltip>
     <RimTalk.Settings.PauseAtSpeed>高速時にAIを一時停止</RimTalk.Settings.PauseAtSpeed>
     <RimTalk.Settings.DisableAiAtSpeedTooltip>API呼び出しを減らすため、ゲーム速度がこのレベル以上に設定されるとAIは一時停止します。</RimTalk.Settings.DisableAiAtSpeedTooltip>
     <RimTalk.Settings.Disabled>無効</RimTalk.Settings.Disabled>

--- a/Languages/Korean/Keyed/RimTalk.xml
+++ b/Languages/Korean/Keyed/RimTalk.xml
@@ -91,6 +91,8 @@
     <RimTalk.Settings.AllowOtherFactionsToTalkTooltip>이 옵션을 활성화하면 다른 세력의 구성원이 AI 생성 대화를 할 수 있습니다.</RimTalk.Settings.AllowOtherFactionsToTalkTooltip>
     <RimTalk.Settings.AllowEnemiesToTalk>적들이 말하도록 허용</RimTalk.Settings.AllowEnemiesToTalk>
     <RimTalk.Settings.AllowEnemiesToTalkTooltip>이 옵션을 활성화하면 적들이 AI 생성 대화를 할 수 있습니다.</RimTalk.Settings.AllowEnemiesToTalkTooltip>
+    <RimTalk.Settings.AllowBabiesToTalk>영아와 유아가 말하도록 허용</RimTalk.Settings.AllowBabiesToTalk>
+    <RimTalk.Settings.AllowBabiesToTalkTooltip>이 옵션을 활성화하면 영아와 유아가 AI 생성 대화를 할 수 있습니다.</RimTalk.Settings.AllowBabiesToTalkTooltip>
     <RimTalk.Settings.PauseAtSpeed>고속에서 AI 일시정지</RimTalk.Settings.PauseAtSpeed>
     <RimTalk.Settings.DisableAiAtSpeedTooltip>API 호출을 줄이기 위해 게임 속도가 이 수준 이상으로 설정되면 AI가 일시정지됩니다.</RimTalk.Settings.DisableAiAtSpeedTooltip>
     <RimTalk.Settings.Disabled>비활성화됨</RimTalk.Settings.Disabled>

--- a/Languages/Russian/Keyed/RimTalk.xml
+++ b/Languages/Russian/Keyed/RimTalk.xml
@@ -91,6 +91,8 @@
     <RimTalk.Settings.AllowOtherFactionsToTalkTooltip>Включите, чтобы разрешить членам других фракций вести разговоры, сгенерированные ИИ.</RimTalk.Settings.AllowOtherFactionsToTalkTooltip>
     <RimTalk.Settings.AllowEnemiesToTalk>Разрешить врагам говорить</RimTalk.Settings.AllowEnemiesToTalk>
     <RimTalk.Settings.AllowEnemiesToTalkTooltip>Включите, чтобы разрешить врагам вести разговоры, сгенерированные ИИ.</RimTalk.Settings.AllowEnemiesToTalkTooltip>
+    <RimTalk.Settings.AllowBabiesToTalk>Разрешить младенцам и детям говорить</RimTalk.Settings.AllowBabiesToTalk>
+    <RimTalk.Settings.AllowBabiesToTalkTooltip>Включите, чтобы младенцы и маленькие дети могли участвовать в разговорах, сгенерированные ИИ.</RimTalk.Settings.AllowBabiesToTalkTooltip>
     <RimTalk.Settings.PauseAtSpeed>Приостанавливать ИИ на высокой скорости</RimTalk.Settings.PauseAtSpeed>
     <RimTalk.Settings.DisableAiAtSpeedTooltip>Чтобы уменьшить количество вызовов API, ИИ будет приостановлен, когда скорость игры установлена на этот уровень или выше.</RimTalk.Settings.DisableAiAtSpeedTooltip>
     <RimTalk.Settings.Disabled>Отключено</RimTalk.Settings.Disabled>

--- a/Source/Service/PawnService.cs
+++ b/Source/Service/PawnService.cs
@@ -15,19 +15,23 @@ public static class PawnService
         if (pawn.IsPlayer()) return true;
         if (pawn.DestroyedOrNull() || !pawn.Spawned || pawn.Dead) return false;
         if (!pawn.RaceProps.Humanlike) return false;
-        if (pawn.ageTracker?.CurLifeStage?.developmentalStage < DevelopmentalStage.Child) return false;
+        RimTalkSettings settings = Settings.Get();
+        if (!settings.AllowBabiesToTalk &&
+            pawn.ageTracker?.CurLifeStage?.developmentalStage < DevelopmentalStage.Child)
+        {
+            return false;
+        }
+
         if (pawn.RaceProps.intelligence < Intelligence.Humanlike) return false;
         if (!pawn.health.capacities.CapableOf(PawnCapacityDefOf.Talking)) return false;
         if (pawn.skills?.GetSkill(SkillDefOf.Social) == null) return false;
 
-        RimTalkSettings settings = Settings.Get();
         return pawn.IsFreeColonist ||
-               (settings.AllowSlavesToTalk && pawn.IsSlave) ||
-               (settings.AllowPrisonersToTalk && pawn.IsPrisoner) ||
-               (settings.AllowOtherFactionsToTalk && pawn.IsVisitor()) ||
-               (settings.AllowEnemiesToTalk && pawn.IsEnemy());
+            (settings.AllowSlavesToTalk && pawn.IsSlave) ||
+            (settings.AllowPrisonersToTalk && pawn.IsPrisoner) ||
+            (settings.AllowOtherFactionsToTalk && pawn.IsVisitor()) ||
+            (settings.AllowEnemiesToTalk && pawn.IsEnemy());
     }
-
     public static HashSet<Hediff> GetHediffs(this Pawn pawn)
     {
         return pawn?.health.hediffSet.hediffs.Where(hediff => hediff.Visible).ToHashSet();

--- a/Source/Settings/RimTalkSettings.cs
+++ b/Source/Settings/RimTalkSettings.cs
@@ -31,6 +31,8 @@ public class RimTalkSettings : ModSettings
     public int DisableAiAtSpeed = 0;
     public ButtonDisplayMode ButtonDisplay = ButtonDisplayMode.Tab;
 
+    public bool AllowBabiesToTalk = false;
+
     // Debug mode settings
     public bool DebugModeEnabled = false;
     public bool DebugGroupingEnabled = false;
@@ -159,6 +161,7 @@ public class RimTalkSettings : ModSettings
         Scribe_Values.Look(ref ContinueDialogueWhileSleeping, "continueDialogueWhileSleeping", false);
         Scribe_Values.Look(ref DisableAiAtSpeed, "DisableAiAtSpeed", 0);
         Scribe_Collections.Look(ref EnabledArchivableTypes, "enabledArchivableTypes", LookMode.Value, LookMode.Value);
+        Scribe_Values.Look(ref AllowBabiesToTalk, "allowBabiesToTalk", false);
 
         // Debug window settings
         Scribe_Values.Look(ref ButtonDisplay, "buttonDisplay", ButtonDisplayMode.Tab, true);

--- a/Source/Settings/Settings_Basic.cs
+++ b/Source/Settings/Settings_Basic.cs
@@ -104,6 +104,10 @@ public partial class Settings
         rightListing.Gap(12f);
         rightListing.CheckboxLabeled("RimTalk.Settings.AllowEnemiesToTalk".Translate().ToString(),
             ref settings.AllowEnemiesToTalk, "RimTalk.Settings.AllowEnemiesToTalkTooltip".Translate().ToString());
+        rightListing.Gap(12f);
+        rightListing.CheckboxLabeled("RimTalk.Settings.AllowBabiesToTalk".Translate().ToString(),
+            ref settings.AllowBabiesToTalk, "RimTalk.Settings.AllowBabiesToTalkTooltip".Translate().ToString());
+
 
         rightListing.End();
 
@@ -201,6 +205,7 @@ public partial class Settings
             settings.AllowPrisonersToTalk = true;
             settings.AllowOtherFactionsToTalk = false;
             settings.AllowEnemiesToTalk = false;
+            settings.AllowBabiesToTalk = false;
             settings.AllowCustomConversation = true;
             settings.ContinueDialogueWhileSleeping = false;
             settings.UseSimpleConfig = true;


### PR DESCRIPTION
## Content
Add a setting for users to allow babies to talk.
<img width="644" height="142" alt="image" src="https://github.com/user-attachments/assets/f5ed654e-7e86-42d4-a801-23aaccf29a3f" />
PTAL.