### PR TITLE
fix: Fix healthcard of vocal link

### DIFF
--- a/Source/Patch/HealthCardUtilityPatch.cs
+++ b/Source/Patch/HealthCardUtilityPatch.cs
@@ -14,15 +14,54 @@ public static class Patch_HealthCardUtility_DrawHediffRow
 {
     public static void Prefix(Rect rect, Pawn pawn, IEnumerable<Hediff> diffs, ref float curY)
     {
-        if (diffs.Any(h => h.def == Constant.VocalLinkDef))
+        if (pawn == null)
         {
-            Rect rowRect = new Rect(0f, curY, rect.xMax, 22f);
+            return;
+        }
+        if (!diffs.Any(h => h.def == Constant.VocalLinkDef))
+        {
+            return;
+        }
+        float leftWidth = rect.width * 0.375f;
+        float textWidth = rect.width - leftWidth;
 
-            if (Widgets.ButtonInvisible(rowRect, false))
+        float simulatedCurY = curY;
+
+        foreach (var group in diffs.GroupBy(h => h.UIGroupKey))
+        {
+            int count = 0;
+            Hediff first = null;
+
+            foreach (var hediff in group)
             {
-                Find.WindowStack.Add(new PersonaEditorWindow(pawn));
-                Event.current.Use();
+                if (count == 0)
+                {
+                    first = hediff;
+                }
+                count++;
             }
+            if (first == null)
+            {
+                continue;
+            }
+            string label = first.LabelCap;
+            if (count != 1)
+            {
+                label = $"{label} x{count.ToStringCached()}";
+            }
+
+            float rowHeight = Verse.Text.CalcHeight(label, textWidth);
+            Rect rowRect = new Rect(leftWidth, simulatedCurY, textWidth, rowHeight);
+            if (group.Any(h => h.def == Constant.VocalLinkDef))
+            {
+                if (Widgets.ButtonInvisible(rowRect, false))
+                {
+                    Find.WindowStack.Add(new PersonaEditorWindow(pawn));
+                    Event.current.Use(); 
+                }
+            }
+
+            simulatedCurY += rowHeight;
         }
     }
 }


### PR DESCRIPTION
## Content
A small fix to put the clickable area of vocal link in the correct place, when vocal link is not on the first line.
PTAL.