### PR TITLE
fix: Add Setting to forbid monologues

### DIFF
--- a/Languages/ChineseSimplified/Keyed/Translation_ChineseSimplified.xml
+++ b/Languages/ChineseSimplified/Keyed/Translation_ChineseSimplified.xml
@@ -99,6 +99,8 @@
     <RimTalk.Settings.AllowBabiesToTalkTooltip>启用此项以允许婴幼儿进行 AI 生成的对话。</RimTalk.Settings.AllowBabiesToTalkTooltip>
     <RimTalk.Settings.AllowNonHumanToTalk>允许非人类说话</RimTalk.Settings.AllowNonHumanToTalk>
     <RimTalk.Settings.AllowNonHumanToTalkTooltip>启用非人类生物（动物、机械人或自定义种族）在获得商人提供的Vocal Link Catalyst后说话。</RimTalk.Settings.AllowNonHumanToTalkTooltip>
+    <RimTalk.Settings.OnlyTalkToOthers>禁止自言自语</RimTalk.Settings.OnlyTalkToOthers>
+    <RimTalk.Settings.OnlyTalkToOthersTooltip>启用后，AI 不会为单独的 Pawn 生成自言自语，只会在有其他 Pawn 参与时生成对话。</RimTalk.Settings.OnlyTalkToOthersTooltip>
     <RimTalk.Settings.ApplyMoodAndSocialEffects>影响心情与社交</RimTalk.Settings.ApplyMoodAndSocialEffects>
     <RimTalk.Settings.ApplyMoodAndSocialEffectsTooltip>对话会根据内容影响殖民者的心情和关系。</RimTalk.Settings.ApplyMoodAndSocialEffectsTooltip>
 

--- a/Languages/ChineseTraditional/Keyed/Translation_ChineseTraditional.xml
+++ b/Languages/ChineseTraditional/Keyed/Translation_ChineseTraditional.xml
@@ -99,6 +99,8 @@
     <RimTalk.Settings.AllowBabiesToTalkTooltip>啟用此項以允許嬰兒進行 AI 生成的對話。</RimTalk.Settings.AllowBabiesToTalkTooltip>
     <RimTalk.Settings.AllowNonHumanToTalk>允許非人類說話</RimTalk.Settings.AllowNonHumanToTalk>
     <RimTalk.Settings.AllowNonHumanToTalkTooltip>啟用非人類生物（動物、機器人或自定義種族）在獲得商人提供的Vocal Link Catalyst後說話。</RimTalk.Settings.AllowNonHumanToTalkTooltip>
+    <RimTalk.Settings.OnlyTalkToOthers>禁止自言自語</RimTalk.Settings.OnlyTalkToOthers>
+    <RimTalk.Settings.OnlyTalkToOthersTooltip>啟用此項后，角色不會自言自語，祗會在有其他角色参與时進行對話。</RimTalk.Settings.OnlyTalkToOthersTooltip>
     <RimTalk.Settings.ApplyMoodAndSocialEffects>影響心情與社交</RimTalk.Settings.ApplyMoodAndSocialEffects>
     <RimTalk.Settings.ApplyMoodAndSocialEffectsTooltip>對話會根據內容影響殖民者的心情和關係。</RimTalk.Settings.ApplyMoodAndSocialEffectsTooltip>
 

--- a/Languages/English/Keyed/Translation_English.xml
+++ b/Languages/English/Keyed/Translation_English.xml
@@ -99,6 +99,8 @@
     <RimTalk.Settings.AllowBabiesToTalkTooltip>Enable this option to allow infants and toddlers to participate in AI-generated conversations.</RimTalk.Settings.AllowBabiesToTalkTooltip>
     <RimTalk.Settings.AllowNonHumanToTalk>Allow Non-Humans to Talk</RimTalk.Settings.AllowNonHumanToTalk>
     <RimTalk.Settings.AllowNonHumanToTalkTooltip>Enable non-human creatures (animals, mechanoids, or custom races) to talk if they have been given a Vocal Link Catalyst, which can be acquired from merchants.</RimTalk.Settings.AllowNonHumanToTalkTooltip>
+    <RimTalk.Settings.OnlyTalkToOthers>Only talk when others are nearby</RimTalk.Settings.OnlyTalkToOthers>
+    <RimTalk.Settings.OnlyTalkToOthersTooltip>When enabled, pawns will not generate AI-driven monologues and will only talk when at least one other pawn is in the conversation.</RimTalk.Settings.OnlyTalkToOthersTooltip>
     <RimTalk.Settings.ApplyMoodAndSocialEffects>Apply Mood and Social Effects</RimTalk.Settings.ApplyMoodAndSocialEffects>
     <RimTalk.Settings.ApplyMoodAndSocialEffectsTooltip>Dialogue can affect pawns’ mood and relationships based on conversation sentiment.</RimTalk.Settings.ApplyMoodAndSocialEffectsTooltip>
 

--- a/Languages/French/Keyed/Translation_French.xml
+++ b/Languages/French/Keyed/Translation_French.xml
@@ -99,6 +99,8 @@
     <RimTalk.Settings.AllowBabiesToTalkTooltip>Activez ceci pour permettre aux nourrissons et aux tout-petits des conversations générées par l'IA.</RimTalk.Settings.AllowBabiesToTalkTooltip>
     <RimTalk.Settings.AllowNonHumanToTalk>Permettre aux non-humains de parler</RimTalk.Settings.AllowNonHumanToTalk>
     <RimTalk.Settings.AllowNonHumanToTalkTooltip>Permet aux animaux, mécanoïdes et races personnalisées de parler lorsqu'ils sont implantés avec un Catalyseur de lien vocal provenant des marchands.</RimTalk.Settings.AllowNonHumanToTalkTooltip>
+    <RimTalk.Settings.OnlyTalkToOthers>Limiter les dialogues aux interactions avec autrui</RimTalk.Settings.OnlyTalkToOthers>
+    <RimTalk.Settings.OnlyTalkToOthersTooltip>Une fois activé, les colons ne produisent plus de monologues et ne parlent que lorsqu’un autre pion est présent.</RimTalk.Settings.OnlyTalkToOthersTooltip>
     <RimTalk.Settings.ApplyMoodAndSocialEffects>Modifier l'humeur et les relations sociales</RimTalk.Settings.ApplyMoodAndSocialEffects>
     <RimTalk.Settings.ApplyMoodAndSocialEffectsTooltip>Les dialogues peuvent affecter l'humeur et les relations des colons en fonction du ton de la conversation.</RimTalk.Settings.ApplyMoodAndSocialEffectsTooltip>
 

--- a/Languages/Japanese/Keyed/Translation_Japanese.xml
+++ b/Languages/Japanese/Keyed/Translation_Japanese.xml
@@ -99,6 +99,8 @@
     <RimTalk.Settings.AllowBabiesToTalkTooltip>これを有効にすると、乳児や幼児がAI生成の会話を行えるようになります。</RimTalk.Settings.AllowBabiesToTalkTooltip>
     <RimTalk.Settings.AllowNonHumanToTalk>非人間が話すことを許可</RimTalk.Settings.AllowNonHumanToTalk>
     <RimTalk.Settings.AllowNonHumanToTalkTooltip>動物、メカノイド、カスタム種族が、商人から聲音鏈接催化劑を入手した場合に話すことを許可します。</RimTalk.Settings.AllowNonHumanToTalkTooltip>
+    <RimTalk.Settings.OnlyTalkToOthers>他者との会話のみ許可</RimTalk.Settings.OnlyTalkToOthers>
+    <RimTalk.Settings.OnlyTalkToOthersTooltip>有効にすると、ポーンは独り言を生成せず、周囲に他のポーンがいる場合のみ会話します。</RimTalk.Settings.OnlyTalkToOthersTooltip>
     <RimTalk.Settings.ApplyMoodAndSocialEffects>ムードと社会的影響を適用</RimTalk.Settings.ApplyMoodAndSocialEffects>
     <RimTalk.Settings.ApplyMoodAndSocialEffectsTooltip>会話に応じて入植者のムードや関係性に影響を与えることがあります。</RimTalk.Settings.ApplyMoodAndSocialEffectsTooltip>
 

--- a/Languages/Korean/Keyed/Translation_Korean.xml
+++ b/Languages/Korean/Keyed/Translation_Korean.xml
@@ -99,6 +99,8 @@
     <RimTalk.Settings.AllowBabiesToTalkTooltip>이 옵션을 활성화하면 영아와 유아가 AI 생성 대화를 할 수 있습니다.</RimTalk.Settings.AllowBabiesToTalkTooltip>
     <RimTalk.Settings.AllowNonHumanToTalk>비인간 말하도록 허용</RimTalk.Settings.AllowNonHumanToTalk>
     <RimTalk.Settings.AllowNonHumanToTalkTooltip>동물, 메카노이드, 커스텀 종족이 상인에게서 음성 연결 촉매를 획득하면 말할 수 있도록 허용합니다.</RimTalk.Settings.AllowNonHumanToTalkTooltip>
+    <RimTalk.Settings.OnlyTalkToOthers>다른 포온과의 대화만 허용</RimTalk.Settings.OnlyTalkToOthers>
+    <RimTalk.Settings.OnlyTalkToOthersTooltip>이 옵션을 활성화하면 포온은 혼잣말을 하지 않고, 주변에 다른 포온이 있을 때만 대화를 생성합니다.</RimTalk.Settings.OnlyTalkToOthersTooltip>
     <RimTalk.Settings.ApplyMoodAndSocialEffects>기분 및 사회적 영향 적용</RimTalk.Settings.ApplyMoodAndSocialEffects>
     <RimTalk.Settings.ApplyMoodAndSocialEffectsTooltip>대화 내용에 따라 주민의 기분과 관계에 영향을 줍니다.</RimTalk.Settings.ApplyMoodAndSocialEffectsTooltip>
 

--- a/Languages/Russian/Keyed/Translation_Russian.xml
+++ b/Languages/Russian/Keyed/Translation_Russian.xml
@@ -99,6 +99,8 @@
     <RimTalk.Settings.AllowBabiesToTalkTooltip>Включите, чтобы младенцы и маленькие дети могли участвовать в разговорах, сгенерированные ИИ.</RimTalk.Settings.AllowBabiesToTalkTooltip>
     <RimTalk.Settings.AllowNonHumanToTalk>Разрешить говорить не людям</RimTalk.Settings.AllowNonHumanToTalk>
     <RimTalk.Settings.AllowNonHumanToTalkTooltip>Позволяет животным, механоидом и пользовательским расам говорить после установки Катализатора голосовой связи, полученного у торговцев.</RimTalk.Settings.AllowNonHumanToTalkTooltip>
+    <RimTalk.Settings.OnlyTalkToOthers>Разрешать только разговоры с другими</RimTalk.Settings.OnlyTalkToOthers>
+    <RimTalk.Settings.OnlyTalkToOthersTooltip>Если включено, пешки не будут создавать внутренние монологи и будут говорить только при наличии других пешек поблизости.</RimTalk.Settings.OnlyTalkToOthersTooltip>
     <RimTalk.Settings.ApplyMoodAndSocialEffects>Влияние на настроение и социальные связи</RimTalk.Settings.ApplyMoodAndSocialEffects>
     <RimTalk.Settings.ApplyMoodAndSocialEffectsTooltip>Диалоги могут влиять на настроение и отношения колонистов в зависимости от тона разговора.</RimTalk.Settings.ApplyMoodAndSocialEffectsTooltip>
 

--- a/Source/Service/TalkService.cs
+++ b/Source/Service/TalkService.cs
@@ -69,7 +69,14 @@ public static class TalkService
             .Distinct()
             .Take(3)
             .ToList();
+        
+        // If user wants to forbid monologues, and this is NOT a player-initiated request, skip
+        if (settings.OnlyTalkToOthers &&
+            talkRequest.TalkType != TalkType.User &&
+            pawns.Count <= 1)
+        { return false; }
 
+        // Normal monologues
         if (pawns.Count == 1) talkRequest.IsMonologue = true;
 
         // Build the context and decorate the prompt with current status information.

--- a/Source/Settings/RimTalkSettings.cs
+++ b/Source/Settings/RimTalkSettings.cs
@@ -33,6 +33,7 @@ public class RimTalkSettings : ModSettings
     public bool AllowBabiesToTalk = true;
     public bool AllowNonHumanToTalk = true;
     public bool ApplyMoodAndSocialEffects = false;
+    public bool OnlyTalkToOthers = false;
     public int DisableAiAtSpeed = 0;
     public Settings.ButtonDisplayMode ButtonDisplay = Settings.ButtonDisplayMode.Tab;
 
@@ -173,6 +174,7 @@ public class RimTalkSettings : ModSettings
         Scribe_Values.Look(ref AllowBabiesToTalk, "allowBabiesToTalk", true);
         Scribe_Values.Look(ref AllowNonHumanToTalk, "allowNonHumanToTalk", true);
         Scribe_Values.Look(ref ApplyMoodAndSocialEffects, "applyMoodAndSocialEffects", false);
+        Scribe_Values.Look(ref OnlyTalkToOthers, "onlyTalkToOthers", false);
         
         Scribe_Deep.Look(ref Context, "context");
 

--- a/Source/Settings/Settings_Basic.cs
+++ b/Source/Settings/Settings_Basic.cs
@@ -140,6 +140,9 @@ public partial class Settings
         rightListing.Gap(6f);
         rightListing.CheckboxLabeled("RimTalk.Settings.AllowNonHumanToTalk".Translate().ToString(),
             ref settings.AllowNonHumanToTalk, "RimTalk.Settings.AllowNonHumanToTalkTooltip".Translate().ToString());
+        rightListing.Gap(6f);
+        rightListing.CheckboxLabeled("RimTalk.Settings.OnlyTalkToOthers".Translate().ToString(),
+            ref settings.OnlyTalkToOthers, "RimTalk.Settings.OnlyTalkToOthersTooltip".Translate().ToString());
 
         rightListing.End();
 


### PR DESCRIPTION
## Content
The issue is reported by [@life4trinity](https://steamcommunity.com/profiles/76561198093374657)
> Is it possible to disable monologue completely? I just want them to speak one-to-one.

So I add a setting to forbid monologue without changing code structure.
PTAL.