### PR TITLE
feat: Refactor environment scanning

### DIFF
--- a/Source/Service/ContextBuilder.cs
+++ b/Source/Service/ContextBuilder.cs
@@ -344,11 +344,13 @@ public static class ContextBuilder
 
         if (contextSettings.IncludeSurroundings)
         {
-            var items = ContextHelper.CollectNearbyItems(mainPawn, 3);
-            if (items.Any())
             {
-                var grouped = items.GroupBy(i => i).Select(g => g.Count() > 1 ? $"{g.Key} x {g.Count()}" : g.Key);
-                sb.Append($"\nSurroundings: {string.Join(", ", grouped)}");
+                var surroundingsText = ContextHelper.CollectNearbyContextText(mainPawn, 3);
+                if (!string.IsNullOrEmpty(surroundingsText))
+                {
+                    sb.Append("\nSurroundings:\n");
+                    sb.Append(surroundingsText);
+                }
             }
         }
     }

--- a/Source/Util/ContextHelper.cs
+++ b/Source/Util/ContextHelper.cs
@@ -7,6 +7,24 @@ using static RimTalk.Service.PromptService;
 
 namespace RimTalk.Util;
 
+public enum NearbyKind
+{
+    Building,
+    Item,
+    Plant,
+    Animal,
+    Filth
+}
+
+public struct NearbyAgg
+{
+    public NearbyKind Kind;
+    public string Key;        // Stable aggregation key (do NOT use dynamic labels)
+    public string Label;      // Display label (human readable)
+    public int Count;         // Number of instances aggregated
+    public int StackSum;      // For items: sum of stackCount across instances
+}
+
 public static class ContextHelper
 {
     public static string GetPawnLocationStatus(Pawn pawn)
@@ -15,8 +33,8 @@ public static class ContextHelper
             return null;
 
         var room = pawn.GetRoom();
-        return room is { PsychologicallyOutdoors: false } 
-            ? "Indoors".Translate() 
+        return room is { PsychologicallyOutdoors: false }
+            ? "Indoors".Translate()
             : "Outdoors".Translate();
     }
 
@@ -34,7 +52,7 @@ public static class ContextHelper
     {
         if (!pawn.RaceProps.Humanlike)
             return $"{pawn.LabelShort}(Age:{pawn.ageTracker.AgeBiologicalYears};Race:{pawn.def.LabelCap})";
-        
+
         var race = ModsConfig.BiotechActive && pawn.genes?.Xenotype != null
             ? pawn.genes.Xenotype.LabelCap
             : pawn.def.LabelCap;
@@ -47,7 +65,7 @@ public static class ContextHelper
         var data = thing.def.graphicData;
         return data != null && data.linkFlags.HasFlag((Enum)LinkFlags.Wall);
     }
-    
+
     public static string Sanitize(string text, Pawn pawn = null)
     {
         if (pawn != null)
@@ -82,79 +100,238 @@ public static class ContextHelper
         return cells;
     }
 
-    public static List<string> CollectNearbyItems(Pawn pawn, int maxItems)
+    private static List<IntVec3> GetNearbyCellsRadial(Pawn pawn, int radius, bool sameRoomOnly)
     {
-        var items = new List<string>();
-        var seenThings = new HashSet<Thing>();
-        var nearbyCells = GetNearbyCells(pawn);
+        var map = pawn.Map;
+        var origin = pawn.Position;
 
-        foreach (var cell in nearbyCells.InRandomOrder())
+        Room room = null;
+        if (sameRoomOnly)
+            room = origin.GetRoom(map);
+
+        var cells = new List<IntVec3>(128);
+
+        // GenRadial is the standard RimWorld radial cell enumeration
+        foreach (var c in GenRadial.RadialCellsAround(origin, radius, true))
         {
-            if (items.Count >= maxItems)
-                break;
+            if (!c.InBounds(map)) continue;
 
-            var thingsHere = cell.GetThingList(pawn.Map);
+            if (sameRoomOnly && room != null)
+            {
+                var r2 = c.GetRoom(map);
+                if (r2 != room) continue;
+            }
+
+            cells.Add(c);
+        }
+
+        return cells;
+    }
+
+
+    /// <summary>
+    /// RimWorld 1.6 "hidden" is handled by HiddenItemsManager (player discovery / codex),
+    /// not by a ThingComp (CompHiddenable no longer exists in 1.6).
+    /// </summary>
+    public static bool IsHiddenForPlayer(Thing thing)
+    {
+        if (thing?.def == null) return false;
+        if (Find.HiddenItemsManager == null) return false;
+        return Find.HiddenItemsManager.Hidden(thing.def);
+    }
+
+    /// <summary>
+    /// Collect structured nearby context with strong limits to avoid freezing on storage/compression mods.
+    /// The limits are conservative by design; tune if needed.
+    /// </summary>
+    public static List<NearbyAgg> CollectNearbyContext(
+        Pawn pawn,
+        int distance = 5,
+        int maxPerKind = 12,
+        int maxCellsToScan = 18,
+        int maxThingsTotal = 200,
+        int maxItemThings = 120)
+    {
+        if (pawn?.Map == null || pawn.Position == IntVec3.Invalid)
+            return new List<NearbyAgg>();
+
+        var map = pawn.Map;
+
+        // Limit the number of cells to scan (hard cap).
+        var sameRoomOnly = pawn.GetRoom() is { PsychologicallyOutdoors: false };
+        var cells = GetNearbyCellsRadial(pawn, distance, sameRoomOnly);
+        if (cells.Count > maxCellsToScan)
+            cells = cells.Take(maxCellsToScan).ToList();
+
+        var aggs = new Dictionary<string, NearbyAgg>();
+
+        int processedTotal = 0;
+        int processedItems = 0;
+
+        foreach (var cell in cells)
+        {
+            var thingsHere = cell.GetThingList(map);
             if (thingsHere == null || thingsHere.Count == 0)
                 continue;
 
-            // Skip cells with pawns/animals
-            if (thingsHere.Any(t => t?.def != null && 
-                t.def.category != ThingCategory.Building && 
-                t.def.category != ThingCategory.Plant &&
-                t.def.category != ThingCategory.Item && 
-                !t.def.IsFilth))
-                continue;
-
-            // Get one valid thing per category
-            var candidatesByCategory = new Dictionary<ThingCategory, Thing>();
-            foreach (var thing in thingsHere)
+            // Use index loop to reduce foreach iterator overhead under heavy lists.
+            for (int i = 0; i < thingsHere.Count; i++)
             {
-                if (thing?.def == null)
+                if (processedTotal >= maxThingsTotal)
+                    goto DONE;
+
+                var thing = thingsHere[i];
+                if (thing?.def == null) continue;
+                if (thing.DestroyedOrNull()) continue;
+
+                // Skip hidden defs (player undiscovered / codex-hidden).
+                if (Find.HiddenItemsManager != null && Find.HiddenItemsManager.Hidden(thing.def))
                     continue;
 
-                var isValid = thing.def.category == ThingCategory.Building ||
-                              thing.def.category == ThingCategory.Plant ||
-                              thing.def.category == ThingCategory.Item ||
-                              thing.def.IsFilth;
-
-                if (!isValid)
-                    continue;
-
-                if (thing.def.category == ThingCategory.Building && IsWall(thing))
-                    continue;
-
-                if (!candidatesByCategory.ContainsKey(thing.def.category))
-                    candidatesByCategory[thing.def.category] = thing;
-            }
-
-            if (candidatesByCategory.Count == 0)
-                continue;
-
-            var picked = candidatesByCategory.Values.ToList().RandomElement();
-            if (seenThings.Contains(picked))
-                continue;
-
-            seenThings.Add(picked);
-
-            if (picked is Building_Storage storage)
-            {
-                var stored = storage.AllSlotCells()
-                    .SelectMany(c => c.GetThingList(pawn.Map))
-                    .Distinct()
-                    .ToList();
-
-                if (stored.Count > 0)
+                // Hard cap on number of item-things processed. This is the main safeguard against
+                // storage/compression mods that can expose extremely large item lists or expensive enumeration.
+                if (thing.def.category == ThingCategory.Item)
                 {
-                    var storedSample = string.Join(", ", stored.OrderBy(_ => Rand.Value).Take(3).Select(i => i.LabelCap));
-                    items.Add($"{storage.LabelCap} ({storedSample})");
+                    // Skip items in storage/stockpiles/shelves to avoid huge enumerations
+                    // and compatibility issues with compression storage mods.
+                    if (thing.Position.GetSlotGroup(map) != null)
+                        continue;
+
+                    processedItems++;
+                    if (processedItems > maxItemThings)
+                        goto DONE;
+
+                    if (thing.stackCount >= 1000 && thing.def.stackLimit < 1000)
+                        continue;
                 }
-            }
-            else
-            {
-                items.Add(picked.LabelCap);
+
+                processedTotal++;
+
+                // Animals (Pawn) are handled separately.
+                if (thing is Pawn otherPawn)
+                {
+                    if (otherPawn == pawn) continue;
+                    if (!otherPawn.Spawned || otherPawn.Dead) continue;
+                    if (!otherPawn.RaceProps.Animal) continue;
+                    AddAgg(aggs, otherPawn, NearbyKind.Animal);
+                    continue;
+                }
+
+                var cat = thing.def.category;
+
+                if (cat == ThingCategory.Building)
+                {
+                    if (IsWall(thing)) continue;
+                    AddAgg(aggs, thing, NearbyKind.Building);
+                }
+                else if (cat == ThingCategory.Item)
+                {
+                    AddAgg(aggs, thing, NearbyKind.Item);
+                }
+                else if (cat == ThingCategory.Plant)
+                {
+                    AddAgg(aggs, thing, NearbyKind.Plant);
+                }
+                else if (thing.def.IsFilth)
+                {
+                    AddAgg(aggs, thing, NearbyKind.Filth);
+                }
             }
         }
 
-        return items;
+DONE:
+        // Output compression: take top N per kind by instance count.
+        return aggs.Values
+            .GroupBy(a => a.Kind)
+            .SelectMany(g => g
+                .OrderByDescending(x => x.Count)
+                .Take(maxPerKind))
+            .ToList();
+    }
+
+    /// <summary>
+    /// Add/update aggregation entry.
+    /// IMPORTANT: aggregation key must be stable; do NOT use Thing.LabelCap/LabelNoCount as key,
+    /// because many items (books/art) have dynamic labels (title/quality/hp) and will not dedupe.
+    /// </summary>
+    private static void AddAgg(Dictionary<string, NearbyAgg> aggs, Thing thing, NearbyKind kind)
+    {
+        var def = thing.def;
+
+        // Stable display label: for context, prefer def.LabelCap instead of Thing.LabelCap
+        // to avoid embedding dynamic info like book titles, author names, quality, hitpoints, etc.
+        var label = def.LabelCap;
+
+        // Stable key: kind + defName (optionally add stuff if you want to distinguish materials).
+        var key = $"{kind}|{def.defName}";
+
+        if (!aggs.TryGetValue(key, out var agg))
+        {
+            agg = new NearbyAgg
+            {
+                Kind = kind,
+                Key = key,
+                Label = label,
+                Count = 0,
+                StackSum = 0
+            };
+        }
+
+        agg.Count++;
+
+        if (kind == NearbyKind.Item)
+            agg.StackSum += thing.stackCount;
+
+        aggs[key] = agg;
+    }
+
+    public static string FormatNearbyContext(List<NearbyAgg> aggs)
+    {
+        if (aggs == null || aggs.Count == 0)
+            return null;
+
+        string FmtGroup(NearbyKind kind, string title)
+        {
+            var list = aggs.Where(a => a.Kind == kind).ToList();
+            if (list.Count == 0) return null;
+
+            var parts = list.Select(a =>
+            {
+                if (kind == NearbyKind.Item)
+                {
+                    // Reduce noise: only show "(N stacks)" when N > 1.
+                    if (a.Count > 1)
+                        return $"{a.Label} ×{a.StackSum} ({a.Count} stacks)";
+                    return $"{a.Label} ×{a.StackSum}";
+                }
+
+                return a.Count > 1 ? $"{a.Label} ×{a.Count}" : a.Label;
+            });
+
+            return $"{title}: {string.Join(", ", parts)}";
+        }
+
+        var sections = new List<string>
+        {
+            FmtGroup(NearbyKind.Building, "Buildings"),
+            FmtGroup(NearbyKind.Item, "Items"),
+            FmtGroup(NearbyKind.Plant, "Plants"),
+            FmtGroup(NearbyKind.Animal, "Animals"),
+            FmtGroup(NearbyKind.Filth, "Filth"),
+        }.Where(s => !string.IsNullOrWhiteSpace(s));
+
+        return string.Join("\n", sections);
+    }
+
+    public static string CollectNearbyContextText(
+        Pawn pawn,
+        int distance = 5,
+        int maxPerKind = 12,
+        int maxCellsToScan = 18,
+        int maxThingsTotal = 200,
+        int maxItemThings = 120)
+    {
+        var aggs = CollectNearbyContext(pawn, distance, maxPerKind, maxCellsToScan, maxThingsTotal, maxItemThings);
+        return FormatNearbyContext(aggs);
     }
 }


### PR DESCRIPTION
The issue is suggested by [@ruaji](https://steamcommunity.com/id/ruaji)

- Why not an add-on mod? - [Rimtalk prompts expansion](https://steamcommunity.com/sharedfiles/filedetails/?id=3628795263&searchtext=Rimtalk) already relies on this file `ContextHelper.cs`. 
# Content

Fix environment context sampling: prevent through-wall reads, remove self-animal loops, dedupe by def, and hard-cap scanning to avoid storage/compression freezes

---

## Background / Problem Statement

RimTalk’s environment context extraction was frequently incorrect and unstable in RimWorld 1.6:

1. **Animals duplicated / self-included** when an animal was the talk request initiator (the speaker could be re-counted as a nearby animal).
2. **“Vision” anomalies**: indoor contexts could ignore nearby furniture while incorrectly reading far-away outdoor plants (e.g., wheat) through walls.
3. **Overly large building counts** (e.g., cradles ×9) due to sampling logic scanning a long strip in front of the pawn rather than true “nearby” cells.
4. **Storage/compression mods could freeze the process** because the collector enumerated too many item Things (including stored inventory stacks).

---

## Root Causes

* Nearby sampling used a **forward-facing “strip scan”** (3-wide columns along facing direction), with **no room/visibility constraints**, causing:

  * missing local objects (not on the strip),
  * reading across walls/rooms,
  * large unintended coverage.
* Aggregation used **dynamic labels** (e.g., `LabelCap`/`LabelNoCount`) in some cases, which are unstable for books/art (title/quality/HP), undermining dedup.
* The collector enumerated `cell.GetThingList(map)` without strong caps and without skipping stored items, leading to huge lists and mod-induced performance pathologies.
* RimWorld 1.6 removed `CompHiddenable`; “hidden” can be **player discovery** (HiddenItemsManager) and/or **underground network visuals** (conduits/pipes), which require different handling.

---

## Summary of Changes

### 1) Replace strip-based sampling with radial sampling and (optional) same-room constraint

* Add a radial cell enumerator based on `GenRadial.RadialCellsAround`.
* If pawn is indoors, restrict scan to **same Room** to prevent through-wall reads.
* Retain a small `maxCellsToScan` cap to bound work.

**Effect:** Nearby context becomes spatially correct, respects room boundaries indoors, and stops pulling unrelated distant objects (e.g., outdoor crops).

### 2) Fix self-animal loop

* When scanning pawns, explicitly **skip `otherPawn == pawn`**.

**Effect:** Prevents the talk initiator from being counted as a nearby animal.

### 3) Stabilize aggregation and resolve “duplicate-looking” entries

* Aggregate by **stable key**: `kind + def.defName` (not by label).
* Use **def-based label** (`def.LabelCap`) for display to avoid dynamic text (book titles/quality/HP) breaking dedup.

**Effect:** Removes repeated/near-duplicate entries caused by label variability and ensures consistent compression of identical defs.

### 4) Add hard limits to avoid freezes and pathological enumerations

* Add strict caps:

  * total Things processed,
  * item Things processed,
  * cells scanned.
* Add a safeguard to **skip items in storage slot groups** (stockpiles/shelves/storage) to avoid huge inventory lists and reduce interaction with compression storage mods.
* Keep optional heuristics for abnormal stacks to reduce noise.

**Effect:** Prevents process stalls/freezes and removes “inventory dump” noise in the environment context.


## Files Touched

* `ContextHelper.cs`

  * New radial sampling helper
  * Updated collection logic (room constraint, caps, storage skip)
  * Aggregation key stabilization and formatting tweaks

---

Thanks for reviewing!
PTAL.