### PR TITLE
feat: Add traveling state indicator to pawn activity

### DIFF
--- a/Source/Util/PawnUtil.cs
+++ b/Source/Util/PawnUtil.cs
@@ -405,6 +405,8 @@ public static class PawnUtil
         "RR_LearnRemotely"
     };
 
+    private static readonly string[] MovementJobPatterns = { "Goto", "Flee", "Wait", "Wander" };
+
     private static string GetActivity(this Pawn pawn)
     {
         if (pawn == null) return null;
@@ -429,6 +431,17 @@ public static class PawnUtil
         if (ResearchJobDefNames.Contains(pawn.CurJob?.def.defName))
         {
             activity = AppendResearchProgress(activity);
+        }
+
+        bool Near(LocalTargetInfo t) => t.IsValid && pawn.Position.InHorDistOf(t.Cell, 5f);
+
+        if (pawn.pather?.Moving == true
+            && !Near(pawn.CurJob.targetA)
+            && !Near(pawn.CurJob.targetB)
+            && !Near(pawn.CurJob.targetC)
+            && !MovementJobPatterns.Any(p => pawn.CurJobDef.defName.Contains(p, StringComparison.OrdinalIgnoreCase)))
+        {
+            activity = $"(traveling to) {activity}";
         }
 
         return activity;


### PR DESCRIPTION
Adds a `(traveling to)` prefix to pawn activity when the pawn is moving toward their job target, helping the LLM distinguish between a pawn's current location and their intended action.

### Issue

The LLM sometimes generates confused dialogue because it can't tell if a pawn is **at** their job location or **traveling to** it. For example:

> **Pawn in Storeroom, assigned to fish:**
> - Activity shows: `"Fishing"`
> - LLM generates:  *"Why am I fishing in the Storeroom? This doesn't make any sense..."*

### Solution

Detect when a pawn is traveling to their job target and prepend `(traveling to)` to the activity:

| Pawn State | Before | After |
|------------|--------|-------|
| Walking to fishing spot | `"Fishing"` | `"(traveling to) Fishing"` |
| Actually fishing | `"Fishing"` | `"Fishing"` |
| Going for a walk | `"Going for a walk"` | `"Going for a walk"` (unchanged) |
| Fleeing | `"Fleeing"` | `"Fleeing"` (unchanged) |
| Walking to billiard table | `"Playing billiards"` | `"(traveling to) Playing billiards"` |
| Repositioning during billiards | `"Playing billiards"` | `"Playing billiards"` (unchanged) |
| Walking to swim | `"Going swimming"` | `"(traveling to) Going swimming"` |
| Swimming in water | `"Going swimming"` | `"Going swimming"` (unchanged) |

### Detection Logic

A pawn is considered "traveling to" their job when **all** of the following are true:

1. **Pawn is moving** (`pawn.pather?.Moving == true`)
2. **Pawn is far from all job targets** (not within 5 cells of targetA/B/C)
3. **Job is not a movement-only job** (pattern exclusion)

#### Distance Check

The 5-cell radius check against all three job targets (A, B, C) distinguishes between:
- **Traveling to job**: Pawn is far (>5 cells) from all job targets? Shows prefix
- **Moving during job**: Pawn is near (<=5 cells) to at least one job target? No prefix

This correctly handles: 
- **"Move-while-doing" jobs** like swimming and billiards, where the pawn constantly moves but stays near the activity location (targetA)
- **Multi-target jobs** like tending (targetA=patient, targetB=medicine, targetC=medicine holder) or watching TV (targetA=TV, targetB=seat, targetC=bed)
- **Partner activities** like strolling together (Romance On The Rim), where the companion may be stored in targetC

#### Pattern Exclusion

Excludes known movement-only jobs by pattern matching to avoid redundant prefixes (e.g., `"(traveling to) Wandering"`).

| Pattern | Matches |
|---------|---------|
| `Goto` | `Goto`, `GotoWander`, `GotoSafeTemperature`, `GotoMindControlled` |
| `Flee` | `Flee`, `FleeAndCower` |
| `Wait` | `Wait`, `Wait_Combat`, `Wait_Wander`, etc. |
| `Wander` | `GotoWander`, `Wait_Wander` |

Any job not matching these patterns while the pawn is moving and far from their target will show the `(traveling to)` indicator.

### Edge Cases

I spot-checked vanilla plus several popular mods that add or modify pawn jobs (Combat Extended, Romance On The Rim, Dubs Bad Hygiene, Hospitality, Gastronomy, Pick Up And Haul) and didn’t see any unintended exclusions.

Even if an undiscovered false positive exists (e.g., a modded JobDef containing "Goto" in its name), it would result in just a missing indicator (showing `"Working..."` instead of `"(traveling to) Working... "`), which is the current behavior anyway; not incorrect, just less informative. 