### PR TITLE
fix: Deduplicate multi-cell buildings during environment context scan

### DIFF
--- a/Source/Util/ContextHelper.cs
+++ b/Source/Util/ContextHelper.cs
@@ -164,6 +164,7 @@ public static class ContextHelper
             cells = cells.Take(maxCellsToScan).ToList();
 
         var aggs = new Dictionary<string, NearbyAgg>();
+        var seenBuildingIds = new HashSet<int>();
 
         int processedTotal = 0;
         int processedItems = 0;
@@ -221,6 +222,7 @@ public static class ContextHelper
 
                 if (cat == ThingCategory.Building)
                 {
+                    if (!seenBuildingIds.Add(thing.thingIDNumber)) continue;
                     if (IsWall(thing)) continue;
                     AddAgg(aggs, thing, NearbyKind.Building);
                 }


### PR DESCRIPTION
Multi-cell buildings (e.g., billiard table, workbench, bed) are currently counted once per cell they occupy when collecting the nearby environment context. This can cause overcounting, e.g., a 2x3 billiard table appearing as "billiard table x6" instead of "billiard table".

### Cause

The context scan logic uses `cell.GetThingList(map)` on every scanned cell and increments a count for every building instance found. Since multi-cell buildings span multiple cells, the same building is counted multiple times in each cell it occupies.

### Solution

- Add a `HashSet<int>` to track building `thingIDNumber` values seen so far during the scan.
- For each building found, only process if its `thingIDNumber` has not already been seen.

When scanning buildings, it tracks already-seen building instances by ID and ignores duplicates. As a result, each multi-cell building is counted only once, regardless of how many scanned cells it occupies.