### PR TITLE
fix: prevent duplicate history entries when pawn speaks multiple times in single call

### DIFF
--- a/Source/Service/TalkService.cs
+++ b/Source/Service/TalkService.cs
@@ -144,9 +144,8 @@ public static class TalkService
     {
         if (!responses.Any()) return;
         string serializedResponses = JsonUtil.SerializeToJson(responses);
-        foreach (var talkResponse in responses)
+        foreach (var pawn in responses.Select(r => Cache.GetByName(r.Name)?.Pawn).Distinct().Where(p => p != null))
         {
-            Pawn pawn = Cache.GetByName(talkResponse.Name)?.Pawn;
             TalkHistory.AddMessageHistory(pawn, prompt, serializedResponses);
         }
     }


### PR DESCRIPTION
### Issue
When a pawn speaks multiple times in a single conversation, `AddResponsesToHistory` loops through every turn and calls `AddMessageHistory` for each occurrence. This causes duplicate history entries for that pawn, which might mistakenly emphasize history for LLM, and possibly spend extra unwanted tokens.

### Example
If a conversation generates 4 turns where Ellie speaks twice: 

```json
[
  {"name":"Ellie","text":"Hey, that reader looks cool. Can I see it?"},
  {"name":"Olesya","text":"Be careful, Ellie. Don't break it."},
  {"name":"Siren","text":"Wow! I want to see too! Are there alien stories in it?"},
  {"name":"Ellie","text":"Don't grab it, Siren. Olesya, read anything interesting lately?"}
]
```

The current foreach loop calls `AddMessageHistory` 4 times (once per turn), resulting in Ellie's history containing: 

```
User: "Ellie starts conversation..."
Assistant: [full conversation JSONL]
User:  "Ellie starts conversation..."     <- DUPLICATE
Assistant: [full conversation JSONL]      <- DUPLICATE
```

### Solution
Change the loop in `AddResponsesToHistory` to iterate over unique pawns instead of every turn.