### PR TITLE
fix: include event defs from XML to address incomplete event scanning

### DIFF
--- a/Source/Settings.cs
+++ b/Source/Settings.cs
@@ -97,6 +97,12 @@ public partial class Settings : Mod
             }
         }
 
+        // Add Defs from XML
+        var letterDefNames = DefDatabase<LetterDef>.AllDefs.Select(def => def.defName);
+        var messageTypeDefNames = DefDatabase<MessageTypeDef>.AllDefs.Select(def => def.defName);
+        foreach (var def in letterDefNames) archivableTypes.Add(def);
+        foreach (var def in messageTypeDefNames) archivableTypes.Add(def);
+
         _discoveredArchivableTypes = archivableTypes.OrderBy(x => x).ToList();
         _archivableTypesScanned = true;
 


### PR DESCRIPTION
The current event scanner only recognizes events defined in C#, and does not include events defined in XML, resulting in some events being missing. This change attempts to resolve this issue.