### PR TITLE
fix: fix NullReferenceException bug in Tickmanager

### DIFF
--- a/Source/Patch/TickManagerPatch.cs
+++ b/Source/Patch/TickManagerPatch.cs
@@ -74,6 +74,11 @@ internal static class TickManagerPatch
             while (UserRequestPool.GetNextUserRequest() is { } pawn)
             {
                 var pawnState = Cache.Get(pawn);
+                if (pawnState == null)
+                {
+                    UserRequestPool.Remove(pawn);
+                    continue;
+                }
                 var request = pawnState.GetNextTalkRequest();
                 
                 if (request == null)


### PR DESCRIPTION
## Content

Fix bug:
```
Root level exception in Update(): System.NullReferenceException: Object reference not set to an instance of an object
[Ref 785DDA32]
  at RimTalk.Patch.TickManagerPatch.Postfix () [0x00179] in /Users/chris/RiderProjects/RimTalk/Source/Patch/TickManagerPatch.cs:77 
  at Verse.TickManager.DoSingleTick () [0x003d4] in <46372f5dadbf4af8939e608076251180>:0 
    - PREFIX OskarPotocki.VEF: Void VEF.Maps.VanillaExpandedFramework_DoSingleTick_Patch:Prefix(Stopwatch& __state)
    - POSTFIX OskarPotocki.VEF: Void VEF.Maps.VanillaExpandedFramework_DoSingleTick_Patch:Postfix(Stopwatch __state)
    - POSTFIX cj.rimtalk: Void RimTalk.Patch.TickManagerPatch:Postfix()
    - POSTFIX RimTalk_LiteratureExpansion: Void RimTalk_LiteratureExpansion.patches.Patch_Tick_DailyScan:Postfix()
  at Verse.TickManager.TickManagerUpdate () [0x00087] in <46372f5dadbf4af8939e608076251180>:0 
  at Verse.Game.UpdatePlay () [0x00018] in <46372f5dadbf4af8939e608076251180>:0 
  at Verse.Root_Play.Update () [0x00032] in <46372f5dadbf4af8939e608076251180>:0 
Root level exception in Update(): System.NullReferenceException: Object reference not set to an instance of an object
[Ref 785DDA32] Duplicate stacktrace, see ref for original
```
by adding a NullReferenceException check.
PTAL.