### PR TITLE
fix: custom instruction lost after prompt system update

### DIFF
--- a/Source/Prompt/PromptManager.cs
+++ b/Source/Prompt/PromptManager.cs
@@ -216,6 +216,11 @@ public class PromptManager : IExposable
     // Creates default preset - entry order is determined by list position (drag-to-reorder like SillyTavern)
     private PromptPreset CreateDefaultPreset()
     {
+        var settings = Settings.Get();
+        var baseInstruction = string.IsNullOrWhiteSpace(settings.CustomInstruction)
+            ? Constant.DefaultInstruction
+            : settings.CustomInstruction;
+
         return new PromptPreset
         {
             Name = "RimTalk Default",
@@ -229,7 +234,7 @@ public class PromptManager : IExposable
                     Name = "Base Instruction",
                     Role = PromptRole.System,
                     Position = PromptPosition.Relative,
-                    Content = Constant.DefaultInstruction
+                    Content = baseInstruction
                 },
                 new()
                 {

--- a/Source/Settings/RimTalkSettings.cs
+++ b/Source/Settings/RimTalkSettings.cs
@@ -250,7 +250,6 @@ public class RimTalkSettings : ModSettings
         if (Scribe.mode == LoadSaveMode.PostLoadInit && !string.IsNullOrWhiteSpace(CustomInstruction))
         {
             PromptSystem.MigrateLegacyInstruction(CustomInstruction);
-            CustomInstruction = ""; // Clear after migration
         }
             
         // Ensure we have at least one cloud config


### PR DESCRIPTION
Fixes a bug where users' custom prompts disappeared after updating the mod. 

### Issue
After the Steam Workshop update, users report their custom instructions were gone. This happened because:

1. `CreateDefaultPreset()` always used `Constant.DefaultInstruction`, ignoring the user's saved `CustomInstruction`
2. `CustomInstruction` was cleared after migration, but Simple Mode still needed it

### Changes
- `PromptManager.CreateDefaultPreset()`: Use `settings.CustomInstruction` if available
- `RimTalkSettings.ExposeData()`: Keep `CustomInstruction` after migration