### PR TITLE
fix: cache Simple Mode preset to prevent reset on every dialogue

### DIFF
--- a/Source/Prompt/PromptManager.cs
+++ b/Source/Prompt/PromptManager.cs
@@ -40,6 +40,10 @@ public class PromptManager : IExposable
     /// <summary>Global variable store (for setvar/getvar)</summary>
     public VariableStore VariableStore = new();
 
+    /// <summary>Cached preset for Simple Mode to avoid recreation on every call</summary>
+    private PromptPreset _simplePresetCache;
+    private string _simplePresetCacheKey = "";
+
     /// <summary>Gets the currently active preset</summary>
     public PromptPreset GetActivePreset()
     {
@@ -366,8 +370,22 @@ public class PromptManager : IExposable
         context.DialoguePrompt = talkRequest.Prompt;
         LastContext = context;
 
-        // 3. Select Preset (Active for Advanced, Default for Simple)
-        var preset = (settings.UseAdvancedPromptMode) ? GetActivePreset() : CreateDefaultPreset();
+        // 3. Select Preset (Active for Advanced, Cached for Simple)
+        PromptPreset preset;
+        if (settings.UseAdvancedPromptMode)
+        {
+            preset = GetActivePreset();
+        }
+        else
+        {
+            var cacheKey = settings.CustomInstruction ?? "";
+            if (_simplePresetCache == null || _simplePresetCacheKey != cacheKey)
+            {
+                _simplePresetCache = CreateDefaultPreset();
+                _simplePresetCacheKey = cacheKey;
+            }
+            preset = _simplePresetCache;
+        }
         if (preset == null) preset = CreateDefaultPreset();
 
         // 4. Build and return


### PR DESCRIPTION
### Issue

User reported that the prompt in Simple Mode constantly resets to the default.

Upon check, in Simple Mode, `CreateDefaultPreset()` is called on every dialogue generation, causing the custom instruction to reset if `settings.CustomInstruction` is empty or fails to load.

### Solution

Cache the Simple Mode preset and only recreate it when `CustomInstruction` actually changes
- Add `_simplePresetCache` and `_simplePresetCacheKey` fields to `PromptManager`
- Modify `BuildMessages()` to use cached preset for Simple Mode