### PR TITLE
feat: Add date/season shorthands to Scriban templates

### DIFF
--- a/Source/Prompt/Parser/ScribanParser.cs
+++ b/Source/Prompt/Parser/ScribanParser.cs
@@ -56,15 +56,24 @@ public static class ScribanParser
             // 3. ROOT PROPERTIES & SYSTEM
             scriptObject.Add("lang", Constant.Lang);
             
-            // Time shorthand
+            // Time & Date shorthands
+            var ticks = Find.TickManager.TicksAbs;
             if (context.Map != null)
             {
                 var longLat = Find.WorldGrid.LongLatOf(context.Map.Tile);
-                scriptObject.Add("hour", GenDate.HourOfDay(Find.TickManager.TicksAbs, longLat.x));
+                scriptObject.Add("hour", GenDate.HourOfDay(ticks, longLat.x));
+                scriptObject.Add("day", GenDate.DayOfQuadrum(ticks, longLat.x) + 1);
+                scriptObject.Add("quadrum", GenDate.Quadrum(ticks, longLat.x).Label());
+                scriptObject.Add("year", GenDate.Year(ticks, longLat.x));
+                scriptObject.Add("season", GenLocalDate.Season(context.Map).Label());
             }
             else
             {
-                scriptObject.Add("hour", GenDate.HourOfDay(Find.TickManager.TicksAbs, 0));
+                scriptObject.Add("hour", GenDate.HourOfDay(ticks, 0));
+                scriptObject.Add("day", GenDate.DayOfQuadrum(ticks, 0) + 1);
+                scriptObject.Add("quadrum", GenDate.Quadrum(ticks, 0).Label());
+                scriptObject.Add("year", GenDate.Year(ticks, 0));
+                scriptObject.Add("season", Season.Undefined.Label());
             }
             
             var json = new ScriptObject();

--- a/Source/Prompt/Parser/VariableDefinitions.cs
+++ b/Source/Prompt/Parser/VariableDefinitions.cs
@@ -93,6 +93,11 @@ public static class VariableDefinitions
         dict["RimTalk.ScribanVar.Category.System".Translate()] = new()
         {
             ("lang", "Active native language name"),
+            ("hour", "Current hour (0-23)"),
+            ("day", "Day of quadrum (1-15)"),
+            ("quadrum", "Current quadrum (Aprimay, Jugust, Septober, Decembary)"),
+            ("year", "Current year (e.g. 5500)"),
+            ("season", "Current season (Spring, Summer, Fall, Winter)"),
             ("json.format", "JSON output instructions"),
             ("chat.history", "Full conversation history (Role: Message)")
         };


### PR DESCRIPTION
**Description**
Previously only hour was available as a time-related shorthand. This PR extends it to include day, quadrum, year, and season.

**New Variables**
- day - Day of quadrum (1-15)
- quadrum - Aprimay, Jugust, Septober, Decembary
- year - e.g. 5507
- season - Spring, Summer, Fall, Winter

``` scriban
{{ year }} {{ quadrum }} Day {{ day }}, {{ season }}
→ 5507 Jugust Day 9, Summer
```