### PR TITLE
fix: revert base instruction into settings

### DIFF
--- a/Source/Settings/RimTalkSettings.cs
+++ b/Source/Settings/RimTalkSettings.cs
@@ -253,6 +253,32 @@ public class RimTalkSettings : ModSettings
         
         // Set the singleton instance
         PromptManager.SetInstance(PromptSystem);
+
+        if (Scribe.mode == LoadSaveMode.PostLoadInit && LanguageDatabase.activeLanguage != null)
+        {
+            bool changed = false;
+            if (PromptSystem.Presets == null || PromptSystem.Presets.Count == 0)
+            {
+                PromptSystem.InitializeDefaults();
+                changed = true;
+            }
+
+            foreach (var preset in PromptSystem.Presets)
+            {
+                int beforeCount = preset.Entries.Count;
+                var baseEntry = GetOrCreateBaseInstructionEntry(preset);
+                if (preset.Entries.Count != beforeCount)
+                    changed = true;
+                if (baseEntry != null && string.IsNullOrWhiteSpace(baseEntry.Content))
+                {
+                    baseEntry.Content = Constant.DefaultInstruction;
+                    changed = true;
+                }
+            }
+
+            if (changed)
+                Write();
+        }
             
         // One-time migration from legacy customInstruction into Base Instruction
         if (Scribe.mode == LoadSaveMode.PostLoadInit && !string.IsNullOrWhiteSpace(_legacyCustomInstruction))


### PR DESCRIPTION
## Content

The bug is reported by [@rynskey](https://steamcommunity.com/id/rynskey)

> After a recent update, the instruction prompts were removed and no dialogue is generated in the game.

Put base instruction into settings if instruction is null.

PTAL. 