### PR TITLE
fix:Restore missing `setvar`/`getvar` function registration

### DIFF
--- a/Source/Prompt/PromptManager.cs
+++ b/Source/Prompt/PromptManager.cs
@@ -363,7 +363,8 @@ public class PromptManager : IExposable
             if (preset == null) preset = CreateDefaultPreset();
         }
 
-        // 4. Build and return
+        // 4. Reset session variables and build
+        ScribanParser.ResetSessionVariables();
         var segments = new List<PromptMessageSegment>();
         var messages = BuildMessagesFromPreset(preset, context, segments);
         


### PR DESCRIPTION
This restores the `setvar`/`getvar` function registration that was inadvertently omitted during the squash merge of #68.

Related to #73