### PR TITLE
fix: Ensure chat history saves rendered template content instead of raw prompt

### DIFF
--- a/Source/Prompt/PromptManager.cs
+++ b/Source/Prompt/PromptManager.cs
@@ -145,6 +145,24 @@ public class PromptManager : IExposable
     }
 
     /// <summary>
+    /// Extracts the last user message content from the built messages.
+    /// Used for saving accurate history when using advanced templates.
+    /// </summary>
+    /// <param name="messages">The list of built messages to search</param>
+    /// <returns>The content of the last user message, or empty string if not found</returns>
+    public static string ExtractUserPrompt(List<(Role role, string content)> messages)
+    {
+        if (messages == null || messages.Count == 0)
+            return string.Empty;
+    
+        // Find the last user message
+        var lastUserMessage = messages
+            .LastOrDefault(m => m.role == Role.User);
+    
+        return lastUserMessage.content ?? string.Empty;
+    }
+
+    /// <summary>
     /// Merges consecutive messages with the same role into a single message.
     /// This improves compatibility with APIs that require strict role alternation (e.g., Gemini).
     /// </summary>

--- a/Source/Service/TalkService.cs
+++ b/Source/Service/TalkService.cs
@@ -79,6 +79,13 @@ public static class TalkService
         // Delegate prompt assembly to PromptManager (Handles Simple/Advanced modes and fallbacks)
         talkRequest.PromptMessages = PromptManager.Instance.BuildMessages(talkRequest, pawns, status);
         
+        // Update prompt with the actual rendered content (important for Advanced Mode history)
+        var extracted = PromptManager.ExtractUserPrompt(talkRequest.PromptMessages);
+        if (!string.IsNullOrEmpty(extracted))
+        {
+            talkRequest.Prompt = extracted;
+        }
+        
         // Offload the AI request and processing to a background thread to avoid blocking the game's main thread.
         Task.Run(() => GenerateAndProcessTalkAsync(talkRequest));
 


### PR DESCRIPTION
#### Problem
Currently, even when using **Advanced Mode** with custom Scriban templates, the data saved to the chat history falls back to the **Simple Mode** raw prompt (default instruction strings).
This causes a discrepancy where the AI responds based on the rendered template, but the saved history contains the generic default prompt, breaking the context consistency for future turns.

#### Solution
1.  **Implemented `PromptManager.ExtractUserPrompt`**: Added a helper method to retrieve the actual rendered content of the user message from the built message list.
2.  **Updated [TalkService](cci:2://file:///d:/Develop/RimworldMOD/RimTalk-Work/RimTalk/Source/Service/TalkService.cs:19:0-271:1)**: Modified the conversation generation flow to update `talkRequest.Prompt` with the extracted rendered content immediately after building the messages.

#### Result
Chat history now accurately reflects the actual rendered content (Scriban template output) sent to the AI. This ensures that the conversation context remains consistent with the custom templates used in Advanced Mode.