### PR TITLE
fix: remove baby giggling and crying from ignored mentalstate

### DIFF
--- a/Source/Patch/MentalStatePatch.cs
+++ b/Source/Patch/MentalStatePatch.cs
@@ -10,9 +10,15 @@ public static class MentalStatePatch
 {
     public static void Postfix(Pawn ___pawn, MentalStateDef stateDef, bool __result)
     {
-        if (__result && ___pawn != null)
+        if (__result && ___pawn != null && !ShouldSkipIgnore(stateDef))
         {
             Cache.Get(___pawn)?.IgnoreAllTalkResponses();
         }
+    }
+
+    private static bool ShouldSkipIgnore(MentalStateDef stateDef)
+    {
+        var stateClass = stateDef?.stateClass;
+        return stateClass == typeof(MentalState_BabyGiggle) || stateClass == typeof(MentalState_BabyCry);
     }
 }


### PR DESCRIPTION
# Content

Remove `BabyGiggle` and `BabyCry` from mentalstate patch, so that response of babies would not be frequently ignored.

PTAL.