### PR TITLE
fix: ctx.UserPrompt returns decorated prompt instead of raw user input

### DIFF
--- a/Source/Prompt/Parser/PromptContext.cs
+++ b/Source/Prompt/Parser/PromptContext.cs
@@ -50,8 +50,8 @@ public class PromptContext
     // Convenience properties - obtained from TalkRequest
     public bool IsMonologue => TalkRequest?.IsMonologue ?? false;
     public TalkType TalkType => TalkRequest?.TalkType ?? TalkType.Other;
-    public string UserPrompt => TalkType == TalkType.User ? TalkRequest?.Prompt : null;
-    
+    public string UserPrompt => TalkType == TalkType.User ? TalkRequest?.RawPrompt : null;
+
     // Compatibility property - Pawns alias
     public List<Pawn> Pawns => AllPawns;
     


### PR DESCRIPTION
`ctx.UserPrompt` is documented as "The raw prompt from the user" in `preset.md`, but currently returns the same decorated prompt as `{{ prompt }}` instead of the player's actual input.

Upon check, `PromptContext.UserPrompt` reads `TalkRequest.Prompt` instead of `TalkRequest.RawPrompt`, returning the decorated prompt rather than the user's original input.