### PR TITLE
feat(provider): add GLM (zAI Coding) provider and endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Only the hard-coded provider endpoints are listed here. Custom providers (Anthro
 | DeepSeek | `https://api.deepseek.com/v1/chat/completions` | `https://api.deepseek.com/models` |  |
 | Grok (xAI) | `https://api.x.ai/v1/chat/completions` | `https://api.x.ai/v1/models` |  |
 | GLM (zAI) | `https://api.z.ai/api/paas/v4/chat/completions` | `https://api.z.ai/api/paas/v4/models` |  |
+| GLM (zAI Coding Plan) | `https://api.z.ai/api/coding/paas/v4/chat/completions` | `https://api.z.ai/api/coding/paas/v4/models` |  |
 | OpenRouter | `https://openrouter.ai/api/v1/chat/completions` | `https://openrouter.ai/api/v1/models` | Adds `HTTP-Referer` and `X-Title` headers |
 | Qwen (Intl) | `https://dashscope-intl.aliyuncs.com/compatible-mode/v1/chat/completions` | `https://dashscope-intl.aliyuncs.com/compatible-mode/v1/models` |  |
 | Qwen (CN) | `https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions` | `https://dashscope.aliyuncs.com/compatible-mode/v1/models` |  |

--- a/Source/Settings/AIProvider.cs
+++ b/Source/Settings/AIProvider.cs
@@ -9,6 +9,7 @@ public enum AIProvider
     DeepSeek,
     Grok,
     GLM,
+    GLMCoding,
     AlibabaIntl,
     AlibabaCN,
     OpenRouter,
@@ -63,6 +64,14 @@ public static class AIProviderRegistry
             {
                 EndpointUrl = "https://api.z.ai/api/paas/v4/chat/completions",
                 ListModelsUrl = "https://api.z.ai/api/paas/v4/models"
+            }
+        },
+        {
+            AIProvider.GLMCoding, new ProviderDef
+            {
+                Label = "GLM (Coding)",
+                EndpointUrl = "https://api.z.ai/api/coding/paas/v4/chat/completions",
+                ListModelsUrl = "https://api.z.ai/api/coding/paas/v4/models"
             }
         },
         {


### PR DESCRIPTION
## Summary
- Added a new cloud provider: `GLM (zAI Coding)`
- Added coding-plan endpoints:
  - `https://api.z.ai/api/coding/paas/v4/chat/completions`
  - `https://api.z.ai/api/coding/paas/v4/models`
- Kept existing `GLM (zAI)` provider unchanged
- Updated provider list in `README.md`

## Why
`GLM (zAI)` and `GLM (zAI Coding)` use different endpoint families.  
This adds a dedicated provider so users can select coding-plan endpoints directly.

## Testing
- Built with:
  - `dotnet build RimTalk.csproj -c Release -p:GameVersion=1.6 -p:EnableBubbles=false`
- Verified mod deploy and provider appears in settings dropdown.
