### PR TITLE
fix: revert replyinterval to talkinterval

### DIFF
--- a/Source/Data/PawnState.cs
+++ b/Source/Data/PawnState.cs
@@ -106,8 +106,9 @@ public class PawnState(Pawn pawn)
     public bool CanGenerateTalk()
     {
         if (Pawn.IsPlayer()) return true;
+        var talkInterval = Settings.Get().TalkInterval;
         return !IsGeneratingTalk && CanDisplayTalk() && Pawn.Awake() && TalkResponses.Empty() 
-               && CommonUtil.HasPassed(LastTalkTick, RimTalkSettings.ReplyInterval);
+               && CommonUtil.HasPassed(LastTalkTick, talkInterval);
     }
     
     public void IgnoreTalkResponse()


### PR DESCRIPTION
## Content

Reply to #80 .

The `talkrequest` sending frequency is binding to a const variable `public const int ReplyInterval = 4;` The PR revert it to original setting variable `TalkInterval`. 

PTAL.