### PR TITLE
fix: refactor the TalkRequest schedule and add more settings

### DIFF
--- a/Languages/ChineseSimplified/Keyed/Translation_ChineseSimplified.xml
+++ b/Languages/ChineseSimplified/Keyed/Translation_ChineseSimplified.xml
@@ -178,6 +178,24 @@ Scriban 魔法 (动态内容)
     <RimTalk.Settings.ApiKey>云端 API 密钥</RimTalk.Settings.ApiKey>
     <RimTalk.Settings.GetFreeApiKey>获取免费 API 密钥</RimTalk.Settings.GetFreeApiKey>
     <RimTalk.Settings.AICooldown>AI 冷却时间（秒）：{0}</RimTalk.Settings.AICooldown>
+    <RimTalk.Settings.LLMProcessInterval>LLM 处理 TalkRequest 间隔（秒）：{0}</RimTalk.Settings.LLMProcessInterval>
+    <RimTalk.Settings.AutoTalkRequestInterval>自动创建 TalkRequest 间隔（秒）：{0}</RimTalk.Settings.AutoTalkRequestInterval>
+    <RimTalk.Settings.TalkRequestQueueMax>TalkRequest 队列最大数量：{0}</RimTalk.Settings.TalkRequestQueueMax>
+    <RimTalk.Settings.DisplayTalkInterval>对话显示间隔（秒）：{0}</RimTalk.Settings.DisplayTalkInterval>
+    <RimTalk.Settings.IgnoreWaitSeconds>对话忽略等待时间（秒）：{0}</RimTalk.Settings.IgnoreWaitSeconds>
+    <RimTalk.Settings.ForceSpeakIgnored>等待后强制输出被忽略对话</RimTalk.Settings.ForceSpeakIgnored>
+    <RimTalk.Settings.ForceSpeakIgnoredTooltip>启用后，被父级忽略链阻塞的对话会在等待时间后强制显示。</RimTalk.Settings.ForceSpeakIgnoredTooltip>
+    <RimTalk.Settings.SpeakWhilePaused>允许游戏暂停时说话</RimTalk.Settings.SpeakWhilePaused>
+    <RimTalk.Settings.StopSpeakingInMenus>在设置/调试/对话窗口打开时暂停说话</RimTalk.Settings.StopSpeakingInMenus>
+    <RimTalk.Settings.AdvancedMenuAvoidance>高级窗口规避（主标签、规划、研究等）</RimTalk.Settings.AdvancedMenuAvoidance>
+    <RimTalk.Settings.AlignTimingToNormalSpeed>所有游戏速度应用 1x 相同时序</RimTalk.Settings.AlignTimingToNormalSpeed>
+    <RimTalk.Settings.IgnorePendingHotkeyEnabled>启用忽略所有等待对话热键（Home）</RimTalk.Settings.IgnorePendingHotkeyEnabled>
+    <RimTalk.Settings.ProcessUserTalkRequestImmediately>立刻处理玩家手动插入的 TalkRequest</RimTalk.Settings.ProcessUserTalkRequestImmediately>
+    <RimTalk.Settings.ProcessUserTalkRequestImmediatelyTooltip>启用后，User 类型 TalkRequest 会插入用户队列对顶，并在每个 Tick 进行处理检查。</RimTalk.Settings.ProcessUserTalkRequestImmediatelyTooltip>
+    <RimTalk.Settings.DisplayUserTalkRequestImmediately>立刻显示玩家手动插入的 TalkRequest</RimTalk.Settings.DisplayUserTalkRequestImmediately>
+    <RimTalk.Settings.DisplayUserTalkRequestImmediatelyTooltip>启用后，显示玩家手动对话前会强制忽略所有等待中的对话输出。</RimTalk.Settings.DisplayUserTalkRequestImmediatelyTooltip>
+    <RimTalk.Settings.IgnoreAllPendingNow>立即忽略所有等待中的对话</RimTalk.Settings.IgnoreAllPendingNow>
+    <RimTalk.Settings.IgnorePendingResult>RimTalk：已忽略 {0} 条等待中的对话。</RimTalk.Settings.IgnorePendingResult>
     <RimTalk.Settings.OverrideInteractions>使用 AI 对话覆盖所有互动</RimTalk.Settings.OverrideInteractions>
     <RimTalk.Settings.OverrideInteractionsTooltip>启用此项以允许 AI 覆盖并为所有互动（包括原版 RimWorld 和其他模组）重新生成对话。注意：AI 对话有上述设置的冷却时间。要更频繁地生成对话，请降低冷却时间。</RimTalk.Settings.OverrideInteractionsTooltip>
     <RimTalk.Settings.AllowSimultaneousConversations>允许多组同时对话</RimTalk.Settings.AllowSimultaneousConversations>
@@ -283,7 +301,7 @@ Scriban 魔法 (动态内容)
     <RimTalk.Settings.Preset.Custom>自定义</RimTalk.Settings.Preset.Custom>
     <RimTalk.Settings.Preset.Custom.Desc>用户自定义配置</RimTalk.Settings.Preset.Custom.Desc>
 
-    <RimTalk.Settings.ContextOptions>上下文选项</RimTalk.Settings.ContextOptions>
+    <RimTalk.Settings.ContextOptions>自动生成上下文选项</RimTalk.Settings.ContextOptions>
     <RimTalk.Settings.EnableContextOptimization>启用上下文优化</RimTalk.Settings.EnableContextOptimization>
     <RimTalk.Settings.EnableContextOptimization.Tooltip>优化上下文以减少 Token 使用，同时保留重要信息。\n注意：这可能会降低生成对话的质量。</RimTalk.Settings.EnableContextOptimization.Tooltip>
     <RimTalk.Settings.ConversationHistoryCount>包含的历史对话会话数量</RimTalk.Settings.ConversationHistoryCount>

--- a/Languages/ChineseSimplified/Keyed/Translation_ChineseSimplified.xml
+++ b/Languages/ChineseSimplified/Keyed/Translation_ChineseSimplified.xml
@@ -177,7 +177,6 @@ Scriban 魔法 (动态内容)
     <RimTalk.Settings.EventFilter>事件过滤器</RimTalk.Settings.EventFilter>
     <RimTalk.Settings.ApiKey>云端 API 密钥</RimTalk.Settings.ApiKey>
     <RimTalk.Settings.GetFreeApiKey>获取免费 API 密钥</RimTalk.Settings.GetFreeApiKey>
-    <RimTalk.Settings.AICooldown>AI 冷却时间（秒）：{0}</RimTalk.Settings.AICooldown>
     <RimTalk.Settings.LLMProcessInterval>LLM 处理 TalkRequest 间隔（秒）：{0}</RimTalk.Settings.LLMProcessInterval>
     <RimTalk.Settings.AutoTalkRequestInterval>自动创建 TalkRequest 间隔（秒）：{0}</RimTalk.Settings.AutoTalkRequestInterval>
     <RimTalk.Settings.TalkRequestQueueMax>TalkRequest 队列最大数量：{0}</RimTalk.Settings.TalkRequestQueueMax>

--- a/Languages/ChineseSimplified/Keyed/Translation_ChineseSimplified.xml
+++ b/Languages/ChineseSimplified/Keyed/Translation_ChineseSimplified.xml
@@ -186,16 +186,18 @@ Scriban 魔法 (动态内容)
     <RimTalk.Settings.ForceSpeakIgnored>等待后强制输出被忽略对话</RimTalk.Settings.ForceSpeakIgnored>
     <RimTalk.Settings.ForceSpeakIgnoredTooltip>启用后，被父级忽略链阻塞的对话会在等待时间后强制显示。</RimTalk.Settings.ForceSpeakIgnoredTooltip>
     <RimTalk.Settings.SpeakWhilePaused>允许游戏暂停时说话</RimTalk.Settings.SpeakWhilePaused>
-    <RimTalk.Settings.StopSpeakingInMenus>在设置/调试/对话窗口打开时暂停说话</RimTalk.Settings.StopSpeakingInMenus>
-    <RimTalk.Settings.AdvancedMenuAvoidance>高级窗口规避（主标签、规划、研究等）</RimTalk.Settings.AdvancedMenuAvoidance>
-    <RimTalk.Settings.AlignTimingToNormalSpeed>所有游戏速度应用 1x 相同时序</RimTalk.Settings.AlignTimingToNormalSpeed>
-    <RimTalk.Settings.IgnorePendingHotkeyEnabled>启用忽略所有等待对话热键（Home）</RimTalk.Settings.IgnorePendingHotkeyEnabled>
+    <RimTalk.Settings.StopSpeakingInMenus>在非RimTalk设置/调试窗口打开时暂停说话</RimTalk.Settings.StopSpeakingInMenus>
+    <RimTalk.Settings.AdvancedMenuAvoidance>在高级窗口暂停说话（主标签、规划、研究等）</RimTalk.Settings.AdvancedMenuAvoidance>
+    <RimTalk.Settings.AlignTimingToNormalSpeed>强制按 60 tick/s（1x）调度对话</RimTalk.Settings.AlignTimingToNormalSpeed>
+    <RimTalk.Settings.IgnorePendingHotkeyEnabled>启用跳过所有积压对话热键</RimTalk.Settings.IgnorePendingHotkeyEnabled>
+    <RimTalk.Settings.IgnorePendingHotkey>一键跳过积压对话按键：</RimTalk.Settings.IgnorePendingHotkey>
     <RimTalk.Settings.ProcessUserTalkRequestImmediately>立刻处理玩家手动插入的 TalkRequest</RimTalk.Settings.ProcessUserTalkRequestImmediately>
     <RimTalk.Settings.ProcessUserTalkRequestImmediatelyTooltip>启用后，User 类型 TalkRequest 会插入用户队列对顶，并在每个 Tick 进行处理检查。</RimTalk.Settings.ProcessUserTalkRequestImmediatelyTooltip>
     <RimTalk.Settings.DisplayUserTalkRequestImmediately>立刻显示玩家手动插入的 TalkRequest</RimTalk.Settings.DisplayUserTalkRequestImmediately>
     <RimTalk.Settings.DisplayUserTalkRequestImmediatelyTooltip>启用后，显示玩家手动对话前会强制忽略所有等待中的对话输出。</RimTalk.Settings.DisplayUserTalkRequestImmediatelyTooltip>
     <RimTalk.Settings.IgnoreAllPendingNow>立即忽略所有等待中的对话</RimTalk.Settings.IgnoreAllPendingNow>
     <RimTalk.Settings.IgnorePendingResult>RimTalk：已忽略 {0} 条等待中的对话。</RimTalk.Settings.IgnorePendingResult>
+    <RimTalk.Settings.SkipPendingResult>RimTalk：已跳过 {0} 条积压对话。</RimTalk.Settings.SkipPendingResult>
     <RimTalk.Settings.OverrideInteractions>使用 AI 对话覆盖所有互动</RimTalk.Settings.OverrideInteractions>
     <RimTalk.Settings.OverrideInteractionsTooltip>启用此项以允许 AI 覆盖并为所有互动（包括原版 RimWorld 和其他模组）重新生成对话。注意：AI 对话有上述设置的冷却时间。要更频繁地生成对话，请降低冷却时间。</RimTalk.Settings.OverrideInteractionsTooltip>
     <RimTalk.Settings.AllowSimultaneousConversations>允许多组同时对话</RimTalk.Settings.AllowSimultaneousConversations>

--- a/Languages/ChineseTraditional/Keyed/Translation_ChineseTraditional.xml
+++ b/Languages/ChineseTraditional/Keyed/Translation_ChineseTraditional.xml
@@ -181,7 +181,6 @@ Scriban 魔法 (動態內容)
     <RimTalk.Settings.EventFilter>事件過濾器</RimTalk.Settings.EventFilter>
     <RimTalk.Settings.ApiKey>雲端 API 金鑰</RimTalk.Settings.ApiKey>
     <RimTalk.Settings.GetFreeApiKey>獲取免費 API 金鑰</RimTalk.Settings.GetFreeApiKey>
-    <RimTalk.Settings.AICooldown>AI 冷卻時間（秒）：{0}</RimTalk.Settings.AICooldown>
     <RimTalk.Settings.LLMProcessInterval>LLM 處理 TalkRequest 間隔（秒）：{0}</RimTalk.Settings.LLMProcessInterval>
     <RimTalk.Settings.AutoTalkRequestInterval>自動建立 TalkRequest 間隔（秒）：{0}</RimTalk.Settings.AutoTalkRequestInterval>
     <RimTalk.Settings.TalkRequestQueueMax>TalkRequest 佇列最大數量：{0}</RimTalk.Settings.TalkRequestQueueMax>

--- a/Languages/ChineseTraditional/Keyed/Translation_ChineseTraditional.xml
+++ b/Languages/ChineseTraditional/Keyed/Translation_ChineseTraditional.xml
@@ -182,6 +182,24 @@ Scriban 魔法 (動態內容)
     <RimTalk.Settings.ApiKey>雲端 API 金鑰</RimTalk.Settings.ApiKey>
     <RimTalk.Settings.GetFreeApiKey>獲取免費 API 金鑰</RimTalk.Settings.GetFreeApiKey>
     <RimTalk.Settings.AICooldown>AI 冷卻時間（秒）：{0}</RimTalk.Settings.AICooldown>
+    <RimTalk.Settings.LLMProcessInterval>LLM 處理 TalkRequest 間隔（秒）：{0}</RimTalk.Settings.LLMProcessInterval>
+    <RimTalk.Settings.AutoTalkRequestInterval>自動建立 TalkRequest 間隔（秒）：{0}</RimTalk.Settings.AutoTalkRequestInterval>
+    <RimTalk.Settings.TalkRequestQueueMax>TalkRequest 佇列最大數量：{0}</RimTalk.Settings.TalkRequestQueueMax>
+    <RimTalk.Settings.DisplayTalkInterval>對話顯示間隔（秒）：{0}</RimTalk.Settings.DisplayTalkInterval>
+    <RimTalk.Settings.IgnoreWaitSeconds>對話忽略等待時間（秒）：{0}</RimTalk.Settings.IgnoreWaitSeconds>
+    <RimTalk.Settings.ForceSpeakIgnored>等待後強制輸出被忽略對話</RimTalk.Settings.ForceSpeakIgnored>
+    <RimTalk.Settings.ForceSpeakIgnoredTooltip>啟用後，被父級忽略鏈阻塞的對話會在等待時間後強制顯示。</RimTalk.Settings.ForceSpeakIgnoredTooltip>
+    <RimTalk.Settings.SpeakWhilePaused>允許遊戲暫停時說話</RimTalk.Settings.SpeakWhilePaused>
+    <RimTalk.Settings.StopSpeakingInMenus>在設定/除錯/對話視窗開啟時暫停說話</RimTalk.Settings.StopSpeakingInMenus>
+    <RimTalk.Settings.AdvancedMenuAvoidance>進階視窗規避（主分頁、規劃、研究等）</RimTalk.Settings.AdvancedMenuAvoidance>
+    <RimTalk.Settings.AlignTimingToNormalSpeed>所有遊戲速度套用 1x 相同時序</RimTalk.Settings.AlignTimingToNormalSpeed>
+    <RimTalk.Settings.IgnorePendingHotkeyEnabled>啟用忽略所有等待對話熱鍵（Home）</RimTalk.Settings.IgnorePendingHotkeyEnabled>
+    <RimTalk.Settings.ProcessUserTalkRequestImmediately>立刻處理玩家手動插入的 TalkRequest</RimTalk.Settings.ProcessUserTalkRequestImmediately>
+    <RimTalk.Settings.ProcessUserTalkRequestImmediatelyTooltip>啟用後，User 類型 TalkRequest 會插入使用者佇列最前，並在每個 Tick 檢查處理。</RimTalk.Settings.ProcessUserTalkRequestImmediatelyTooltip>
+    <RimTalk.Settings.DisplayUserTalkRequestImmediately>立刻顯示玩家手動插入的 TalkRequest</RimTalk.Settings.DisplayUserTalkRequestImmediately>
+    <RimTalk.Settings.DisplayUserTalkRequestImmediatelyTooltip>啟用後，在顯示玩家手動對話前會強制忽略所有等待中的對話輸出。</RimTalk.Settings.DisplayUserTalkRequestImmediatelyTooltip>
+    <RimTalk.Settings.IgnoreAllPendingNow>立即忽略所有等待中的對話</RimTalk.Settings.IgnoreAllPendingNow>
+    <RimTalk.Settings.IgnorePendingResult>RimTalk：已忽略 {0} 條等待中的對話。</RimTalk.Settings.IgnorePendingResult>
     <RimTalk.Settings.OverrideInteractions>使用 AI 對話覆蓋所有互動</RimTalk.Settings.OverrideInteractions>
     <RimTalk.Settings.OverrideInteractionsTooltip>啟用此選項以允許 AI 覆蓋並重新生成所有互動的對話（包括 vanilla RimWorld 和其他模組）。注意：AI 對話具有上方設定的冷卻期。要更頻繁地生成對話，請降低冷卻時間。</RimTalk.Settings.OverrideInteractionsTooltip>
     <RimTalk.Settings.AllowSimultaneousConversations>允許同時進行多個對話</RimTalk.Settings.AllowSimultaneousConversations>

--- a/Languages/ChineseTraditional/Keyed/Translation_ChineseTraditional.xml
+++ b/Languages/ChineseTraditional/Keyed/Translation_ChineseTraditional.xml
@@ -190,16 +190,18 @@ Scriban 魔法 (動態內容)
     <RimTalk.Settings.ForceSpeakIgnored>等待後強制輸出被忽略對話</RimTalk.Settings.ForceSpeakIgnored>
     <RimTalk.Settings.ForceSpeakIgnoredTooltip>啟用後，被父級忽略鏈阻塞的對話會在等待時間後強制顯示。</RimTalk.Settings.ForceSpeakIgnoredTooltip>
     <RimTalk.Settings.SpeakWhilePaused>允許遊戲暫停時說話</RimTalk.Settings.SpeakWhilePaused>
-    <RimTalk.Settings.StopSpeakingInMenus>在設定/除錯/對話視窗開啟時暫停說話</RimTalk.Settings.StopSpeakingInMenus>
-    <RimTalk.Settings.AdvancedMenuAvoidance>進階視窗規避（主分頁、規劃、研究等）</RimTalk.Settings.AdvancedMenuAvoidance>
-    <RimTalk.Settings.AlignTimingToNormalSpeed>所有遊戲速度套用 1x 相同時序</RimTalk.Settings.AlignTimingToNormalSpeed>
-    <RimTalk.Settings.IgnorePendingHotkeyEnabled>啟用忽略所有等待對話熱鍵（Home）</RimTalk.Settings.IgnorePendingHotkeyEnabled>
+    <RimTalk.Settings.StopSpeakingInMenus>在非 RimTalk 設定/除錯視窗開啟時暫停說話</RimTalk.Settings.StopSpeakingInMenus>
+    <RimTalk.Settings.AdvancedMenuAvoidance>在進階視窗暫停說話（主分頁、規劃、研究等）</RimTalk.Settings.AdvancedMenuAvoidance>
+    <RimTalk.Settings.AlignTimingToNormalSpeed>強制按 60 tick/s（1x）調度對話</RimTalk.Settings.AlignTimingToNormalSpeed>
+    <RimTalk.Settings.IgnorePendingHotkeyEnabled>啟用跳過所有積壓對話熱鍵</RimTalk.Settings.IgnorePendingHotkeyEnabled>
+    <RimTalk.Settings.IgnorePendingHotkey>一鍵跳過積壓對話按鍵：</RimTalk.Settings.IgnorePendingHotkey>
     <RimTalk.Settings.ProcessUserTalkRequestImmediately>立刻處理玩家手動插入的 TalkRequest</RimTalk.Settings.ProcessUserTalkRequestImmediately>
     <RimTalk.Settings.ProcessUserTalkRequestImmediatelyTooltip>啟用後，User 類型 TalkRequest 會插入使用者佇列最前，並在每個 Tick 檢查處理。</RimTalk.Settings.ProcessUserTalkRequestImmediatelyTooltip>
     <RimTalk.Settings.DisplayUserTalkRequestImmediately>立刻顯示玩家手動插入的 TalkRequest</RimTalk.Settings.DisplayUserTalkRequestImmediately>
     <RimTalk.Settings.DisplayUserTalkRequestImmediatelyTooltip>啟用後，在顯示玩家手動對話前會強制忽略所有等待中的對話輸出。</RimTalk.Settings.DisplayUserTalkRequestImmediatelyTooltip>
     <RimTalk.Settings.IgnoreAllPendingNow>立即忽略所有等待中的對話</RimTalk.Settings.IgnoreAllPendingNow>
     <RimTalk.Settings.IgnorePendingResult>RimTalk：已忽略 {0} 條等待中的對話。</RimTalk.Settings.IgnorePendingResult>
+    <RimTalk.Settings.SkipPendingResult>RimTalk：已跳過 {0} 條積壓對話。</RimTalk.Settings.SkipPendingResult>
     <RimTalk.Settings.OverrideInteractions>使用 AI 對話覆蓋所有互動</RimTalk.Settings.OverrideInteractions>
     <RimTalk.Settings.OverrideInteractionsTooltip>啟用此選項以允許 AI 覆蓋並重新生成所有互動的對話（包括 vanilla RimWorld 和其他模組）。注意：AI 對話具有上方設定的冷卻期。要更頻繁地生成對話，請降低冷卻時間。</RimTalk.Settings.OverrideInteractionsTooltip>
     <RimTalk.Settings.AllowSimultaneousConversations>允許同時進行多個對話</RimTalk.Settings.AllowSimultaneousConversations>

--- a/Languages/English/Keyed/Translation_English.xml
+++ b/Languages/English/Keyed/Translation_English.xml
@@ -186,16 +186,18 @@ Crucial Tips:
     <RimTalk.Settings.ForceSpeakIgnored>Force speak ignored dialogue after wait</RimTalk.Settings.ForceSpeakIgnored>
     <RimTalk.Settings.ForceSpeakIgnoredTooltip>If enabled, lines blocked by ignored parent lines will be forced to speak after the wait time.</RimTalk.Settings.ForceSpeakIgnoredTooltip>
     <RimTalk.Settings.SpeakWhilePaused>Allow speaking while paused</RimTalk.Settings.SpeakWhilePaused>
-    <RimTalk.Settings.StopSpeakingInMenus>Pause speaking while settings/debug/dialog windows are open</RimTalk.Settings.StopSpeakingInMenus>
-    <RimTalk.Settings.AdvancedMenuAvoidance>Advanced menu avoidance (main tabs, planners, research, etc.)</RimTalk.Settings.AdvancedMenuAvoidance>
-    <RimTalk.Settings.AlignTimingToNormalSpeed>Apply the same timing as 1x speed at all game speeds</RimTalk.Settings.AlignTimingToNormalSpeed>
-    <RimTalk.Settings.IgnorePendingHotkeyEnabled>Enable hotkey to ignore all pending dialogue (Home)</RimTalk.Settings.IgnorePendingHotkeyEnabled>
+    <RimTalk.Settings.StopSpeakingInMenus>Pause speaking while non-RimTalk settings/debug/dialog windows are open</RimTalk.Settings.StopSpeakingInMenus>
+    <RimTalk.Settings.AdvancedMenuAvoidance>Pause speaking in advanced windows (main tabs, planners, research, etc.)</RimTalk.Settings.AdvancedMenuAvoidance>
+    <RimTalk.Settings.AlignTimingToNormalSpeed>Schedule dialogue at fixed 60 tick/s (1x baseline)</RimTalk.Settings.AlignTimingToNormalSpeed>
+    <RimTalk.Settings.IgnorePendingHotkeyEnabled>Enable hotkey to skip all pending dialogue</RimTalk.Settings.IgnorePendingHotkeyEnabled>
+    <RimTalk.Settings.IgnorePendingHotkey>Keybind to skip all pending dialogue:</RimTalk.Settings.IgnorePendingHotkey>
     <RimTalk.Settings.ProcessUserTalkRequestImmediately>Process manually inserted user TalkRequests immediately</RimTalk.Settings.ProcessUserTalkRequestImmediately>
     <RimTalk.Settings.ProcessUserTalkRequestImmediatelyTooltip>When enabled, user TalkRequests are pushed to the top of the user queue and checked every tick.</RimTalk.Settings.ProcessUserTalkRequestImmediatelyTooltip>
     <RimTalk.Settings.DisplayUserTalkRequestImmediately>Display manually inserted user TalkRequests immediately</RimTalk.Settings.DisplayUserTalkRequestImmediately>
     <RimTalk.Settings.DisplayUserTalkRequestImmediatelyTooltip>When enabled, all pending dialogue lines are forcibly ignored before displaying user-inserted dialogue.</RimTalk.Settings.DisplayUserTalkRequestImmediatelyTooltip>
     <RimTalk.Settings.IgnoreAllPendingNow>Ignore all pending dialogue now</RimTalk.Settings.IgnoreAllPendingNow>
     <RimTalk.Settings.IgnorePendingResult>RimTalk: Ignored {0} pending dialogue lines.</RimTalk.Settings.IgnorePendingResult>
+    <RimTalk.Settings.SkipPendingResult>RimTalk: Skipped {0} queued dialogue lines.</RimTalk.Settings.SkipPendingResult>
     <RimTalk.Settings.OverrideInteractions>Override All Interactions with AI Dialogue</RimTalk.Settings.OverrideInteractions>
     <RimTalk.Settings.OverrideInteractionsTooltip>Enable this to allow AI to override and regenerate dialogue for all interactions (including vanilla RimWorld and other mods). Note: AI dialogue has a cooldown period set above. To generate dialogue more frequently, lower the cooldown.</RimTalk.Settings.OverrideInteractionsTooltip>
     <RimTalk.Settings.AllowSimultaneousConversations>Allow Simultaneous Conversations</RimTalk.Settings.AllowSimultaneousConversations>

--- a/Languages/English/Keyed/Translation_English.xml
+++ b/Languages/English/Keyed/Translation_English.xml
@@ -177,7 +177,6 @@ Crucial Tips:
     <RimTalk.Settings.EventFilter>Event Filter</RimTalk.Settings.EventFilter>
     <RimTalk.Settings.ApiKey>Cloud API Key</RimTalk.Settings.ApiKey>
     <RimTalk.Settings.GetFreeApiKey>Get a free API key</RimTalk.Settings.GetFreeApiKey>
-    <RimTalk.Settings.AICooldown>AI Cooldown (Seconds): {0}</RimTalk.Settings.AICooldown>
     <RimTalk.Settings.LLMProcessInterval>LLM Process TalkRequest Interval (Seconds): {0}</RimTalk.Settings.LLMProcessInterval>
     <RimTalk.Settings.AutoTalkRequestInterval>Auto-create TalkRequest Interval (Seconds): {0}</RimTalk.Settings.AutoTalkRequestInterval>
     <RimTalk.Settings.TalkRequestQueueMax>TalkRequest Queue Max Size: {0}</RimTalk.Settings.TalkRequestQueueMax>

--- a/Languages/English/Keyed/Translation_English.xml
+++ b/Languages/English/Keyed/Translation_English.xml
@@ -178,6 +178,24 @@ Crucial Tips:
     <RimTalk.Settings.ApiKey>Cloud API Key</RimTalk.Settings.ApiKey>
     <RimTalk.Settings.GetFreeApiKey>Get a free API key</RimTalk.Settings.GetFreeApiKey>
     <RimTalk.Settings.AICooldown>AI Cooldown (Seconds): {0}</RimTalk.Settings.AICooldown>
+    <RimTalk.Settings.LLMProcessInterval>LLM Process TalkRequest Interval (Seconds): {0}</RimTalk.Settings.LLMProcessInterval>
+    <RimTalk.Settings.AutoTalkRequestInterval>Auto-create TalkRequest Interval (Seconds): {0}</RimTalk.Settings.AutoTalkRequestInterval>
+    <RimTalk.Settings.TalkRequestQueueMax>TalkRequest Queue Max Size: {0}</RimTalk.Settings.TalkRequestQueueMax>
+    <RimTalk.Settings.DisplayTalkInterval>Dialogue Display Interval (Seconds): {0}</RimTalk.Settings.DisplayTalkInterval>
+    <RimTalk.Settings.IgnoreWaitSeconds>Ignored-chain Wait Time (Seconds): {0}</RimTalk.Settings.IgnoreWaitSeconds>
+    <RimTalk.Settings.ForceSpeakIgnored>Force speak ignored dialogue after wait</RimTalk.Settings.ForceSpeakIgnored>
+    <RimTalk.Settings.ForceSpeakIgnoredTooltip>If enabled, lines blocked by ignored parent lines will be forced to speak after the wait time.</RimTalk.Settings.ForceSpeakIgnoredTooltip>
+    <RimTalk.Settings.SpeakWhilePaused>Allow speaking while paused</RimTalk.Settings.SpeakWhilePaused>
+    <RimTalk.Settings.StopSpeakingInMenus>Pause speaking while settings/debug/dialog windows are open</RimTalk.Settings.StopSpeakingInMenus>
+    <RimTalk.Settings.AdvancedMenuAvoidance>Advanced menu avoidance (main tabs, planners, research, etc.)</RimTalk.Settings.AdvancedMenuAvoidance>
+    <RimTalk.Settings.AlignTimingToNormalSpeed>Apply the same timing as 1x speed at all game speeds</RimTalk.Settings.AlignTimingToNormalSpeed>
+    <RimTalk.Settings.IgnorePendingHotkeyEnabled>Enable hotkey to ignore all pending dialogue (Home)</RimTalk.Settings.IgnorePendingHotkeyEnabled>
+    <RimTalk.Settings.ProcessUserTalkRequestImmediately>Process manually inserted user TalkRequests immediately</RimTalk.Settings.ProcessUserTalkRequestImmediately>
+    <RimTalk.Settings.ProcessUserTalkRequestImmediatelyTooltip>When enabled, user TalkRequests are pushed to the top of the user queue and checked every tick.</RimTalk.Settings.ProcessUserTalkRequestImmediatelyTooltip>
+    <RimTalk.Settings.DisplayUserTalkRequestImmediately>Display manually inserted user TalkRequests immediately</RimTalk.Settings.DisplayUserTalkRequestImmediately>
+    <RimTalk.Settings.DisplayUserTalkRequestImmediatelyTooltip>When enabled, all pending dialogue lines are forcibly ignored before displaying user-inserted dialogue.</RimTalk.Settings.DisplayUserTalkRequestImmediatelyTooltip>
+    <RimTalk.Settings.IgnoreAllPendingNow>Ignore all pending dialogue now</RimTalk.Settings.IgnoreAllPendingNow>
+    <RimTalk.Settings.IgnorePendingResult>RimTalk: Ignored {0} pending dialogue lines.</RimTalk.Settings.IgnorePendingResult>
     <RimTalk.Settings.OverrideInteractions>Override All Interactions with AI Dialogue</RimTalk.Settings.OverrideInteractions>
     <RimTalk.Settings.OverrideInteractionsTooltip>Enable this to allow AI to override and regenerate dialogue for all interactions (including vanilla RimWorld and other mods). Note: AI dialogue has a cooldown period set above. To generate dialogue more frequently, lower the cooldown.</RimTalk.Settings.OverrideInteractionsTooltip>
     <RimTalk.Settings.AllowSimultaneousConversations>Allow Simultaneous Conversations</RimTalk.Settings.AllowSimultaneousConversations>

--- a/Languages/French/Keyed/Translation_French.xml
+++ b/Languages/French/Keyed/Translation_French.xml
@@ -190,16 +190,18 @@ Conseils Cruciaux :
     <RimTalk.Settings.ForceSpeakIgnored>Forcer l'affichage des dialogues ignorés après l'attente</RimTalk.Settings.ForceSpeakIgnored>
     <RimTalk.Settings.ForceSpeakIgnoredTooltip>Si activé, les répliques bloquées par une ligne parente ignorée seront forcées à s'afficher après le délai d'attente.</RimTalk.Settings.ForceSpeakIgnoredTooltip>
     <RimTalk.Settings.SpeakWhilePaused>Autoriser les dialogues en pause</RimTalk.Settings.SpeakWhilePaused>
-    <RimTalk.Settings.StopSpeakingInMenus>Mettre les dialogues en pause quand les fenêtres paramètres/debug/dialogue sont ouvertes</RimTalk.Settings.StopSpeakingInMenus>
-    <RimTalk.Settings.AdvancedMenuAvoidance>Évitement avancé des menus (onglets, planification, recherche, etc.)</RimTalk.Settings.AdvancedMenuAvoidance>
-    <RimTalk.Settings.AlignTimingToNormalSpeed>Appliquer le même timing que la vitesse x1 à toutes les vitesses</RimTalk.Settings.AlignTimingToNormalSpeed>
-    <RimTalk.Settings.IgnorePendingHotkeyEnabled>Activer le raccourci pour ignorer tous les dialogues en attente (Home)</RimTalk.Settings.IgnorePendingHotkeyEnabled>
+    <RimTalk.Settings.StopSpeakingInMenus>Mettre les dialogues en pause quand des fenêtres paramètres/debug/dialogue non-RimTalk sont ouvertes</RimTalk.Settings.StopSpeakingInMenus>
+    <RimTalk.Settings.AdvancedMenuAvoidance>Mettre les dialogues en pause dans les fenêtres avancées (onglets principaux, planification, recherche, etc.)</RimTalk.Settings.AdvancedMenuAvoidance>
+    <RimTalk.Settings.AlignTimingToNormalSpeed>Planifier les dialogues à 60 tick/s fixes (base x1)</RimTalk.Settings.AlignTimingToNormalSpeed>
+    <RimTalk.Settings.IgnorePendingHotkeyEnabled>Activer le raccourci pour passer tous les dialogues en attente</RimTalk.Settings.IgnorePendingHotkeyEnabled>
+    <RimTalk.Settings.IgnorePendingHotkey>Raccourci pour passer tous les dialogues en attente :</RimTalk.Settings.IgnorePendingHotkey>
     <RimTalk.Settings.ProcessUserTalkRequestImmediately>Traiter immédiatement les TalkRequests utilisateur insérés manuellement</RimTalk.Settings.ProcessUserTalkRequestImmediately>
     <RimTalk.Settings.ProcessUserTalkRequestImmediatelyTooltip>Si activé, les TalkRequests utilisateur sont placés en tête de la file utilisateur et vérifiés à chaque tick.</RimTalk.Settings.ProcessUserTalkRequestImmediatelyTooltip>
     <RimTalk.Settings.DisplayUserTalkRequestImmediately>Afficher immédiatement les TalkRequests utilisateur insérés manuellement</RimTalk.Settings.DisplayUserTalkRequestImmediately>
     <RimTalk.Settings.DisplayUserTalkRequestImmediatelyTooltip>Si activé, toutes les lignes de dialogue en attente sont ignorées de force avant d'afficher un dialogue inséré par l'utilisateur.</RimTalk.Settings.DisplayUserTalkRequestImmediatelyTooltip>
     <RimTalk.Settings.IgnoreAllPendingNow>Ignorer tous les dialogues en attente maintenant</RimTalk.Settings.IgnoreAllPendingNow>
     <RimTalk.Settings.IgnorePendingResult>RimTalk : {0} lignes de dialogue en attente ont été ignorées.</RimTalk.Settings.IgnorePendingResult>
+    <RimTalk.Settings.SkipPendingResult>RimTalk : {0} lignes de dialogue en file ont été passées.</RimTalk.Settings.SkipPendingResult>
     <RimTalk.Settings.OverrideInteractions>Remplacer toutes les interactions par des dialogues de l'IA</RimTalk.Settings.OverrideInteractions>
     <RimTalk.Settings.OverrideInteractionsTooltip>Activez ceci pour permettre à l'IA de remplacer et de régénérer les dialogues pour toutes les interactions (y compris RimWorld vanilla et autres mods). Remarque : les dialogues de l'IA ont une période de recharge définie ci-dessus. Pour générer des dialogues plus fréquemment, diminuez le temps de recharge.</RimTalk.Settings.OverrideInteractionsTooltip>
     <RimTalk.Settings.AllowSimultaneousConversations>Autoriser les conversations simultanées</RimTalk.Settings.AllowSimultaneousConversations>

--- a/Languages/French/Keyed/Translation_French.xml
+++ b/Languages/French/Keyed/Translation_French.xml
@@ -182,6 +182,24 @@ Conseils Cruciaux :
     <RimTalk.Settings.ApiKey>Clé API Cloud</RimTalk.Settings.ApiKey>
     <RimTalk.Settings.GetFreeApiKey>Obtenir une clé API gratuite</RimTalk.Settings.GetFreeApiKey>
     <RimTalk.Settings.AICooldown>Temps de recharge de l'IA (Secondes) : {0}</RimTalk.Settings.AICooldown>
+    <RimTalk.Settings.LLMProcessInterval>Intervalle de traitement des TalkRequest par le LLM (secondes) : {0}</RimTalk.Settings.LLMProcessInterval>
+    <RimTalk.Settings.AutoTalkRequestInterval>Intervalle de création automatique des TalkRequest (secondes) : {0}</RimTalk.Settings.AutoTalkRequestInterval>
+    <RimTalk.Settings.TalkRequestQueueMax>Taille max de la file TalkRequest : {0}</RimTalk.Settings.TalkRequestQueueMax>
+    <RimTalk.Settings.DisplayTalkInterval>Intervalle d'affichage des dialogues (secondes) : {0}</RimTalk.Settings.DisplayTalkInterval>
+    <RimTalk.Settings.IgnoreWaitSeconds>Délai d'attente de la chaîne ignorée (secondes) : {0}</RimTalk.Settings.IgnoreWaitSeconds>
+    <RimTalk.Settings.ForceSpeakIgnored>Forcer l'affichage des dialogues ignorés après l'attente</RimTalk.Settings.ForceSpeakIgnored>
+    <RimTalk.Settings.ForceSpeakIgnoredTooltip>Si activé, les répliques bloquées par une ligne parente ignorée seront forcées à s'afficher après le délai d'attente.</RimTalk.Settings.ForceSpeakIgnoredTooltip>
+    <RimTalk.Settings.SpeakWhilePaused>Autoriser les dialogues en pause</RimTalk.Settings.SpeakWhilePaused>
+    <RimTalk.Settings.StopSpeakingInMenus>Mettre les dialogues en pause quand les fenêtres paramètres/debug/dialogue sont ouvertes</RimTalk.Settings.StopSpeakingInMenus>
+    <RimTalk.Settings.AdvancedMenuAvoidance>Évitement avancé des menus (onglets, planification, recherche, etc.)</RimTalk.Settings.AdvancedMenuAvoidance>
+    <RimTalk.Settings.AlignTimingToNormalSpeed>Appliquer le même timing que la vitesse x1 à toutes les vitesses</RimTalk.Settings.AlignTimingToNormalSpeed>
+    <RimTalk.Settings.IgnorePendingHotkeyEnabled>Activer le raccourci pour ignorer tous les dialogues en attente (Home)</RimTalk.Settings.IgnorePendingHotkeyEnabled>
+    <RimTalk.Settings.ProcessUserTalkRequestImmediately>Traiter immédiatement les TalkRequests utilisateur insérés manuellement</RimTalk.Settings.ProcessUserTalkRequestImmediately>
+    <RimTalk.Settings.ProcessUserTalkRequestImmediatelyTooltip>Si activé, les TalkRequests utilisateur sont placés en tête de la file utilisateur et vérifiés à chaque tick.</RimTalk.Settings.ProcessUserTalkRequestImmediatelyTooltip>
+    <RimTalk.Settings.DisplayUserTalkRequestImmediately>Afficher immédiatement les TalkRequests utilisateur insérés manuellement</RimTalk.Settings.DisplayUserTalkRequestImmediately>
+    <RimTalk.Settings.DisplayUserTalkRequestImmediatelyTooltip>Si activé, toutes les lignes de dialogue en attente sont ignorées de force avant d'afficher un dialogue inséré par l'utilisateur.</RimTalk.Settings.DisplayUserTalkRequestImmediatelyTooltip>
+    <RimTalk.Settings.IgnoreAllPendingNow>Ignorer tous les dialogues en attente maintenant</RimTalk.Settings.IgnoreAllPendingNow>
+    <RimTalk.Settings.IgnorePendingResult>RimTalk : {0} lignes de dialogue en attente ont été ignorées.</RimTalk.Settings.IgnorePendingResult>
     <RimTalk.Settings.OverrideInteractions>Remplacer toutes les interactions par des dialogues de l'IA</RimTalk.Settings.OverrideInteractions>
     <RimTalk.Settings.OverrideInteractionsTooltip>Activez ceci pour permettre à l'IA de remplacer et de régénérer les dialogues pour toutes les interactions (y compris RimWorld vanilla et autres mods). Remarque : les dialogues de l'IA ont une période de recharge définie ci-dessus. Pour générer des dialogues plus fréquemment, diminuez le temps de recharge.</RimTalk.Settings.OverrideInteractionsTooltip>
     <RimTalk.Settings.AllowSimultaneousConversations>Autoriser les conversations simultanées</RimTalk.Settings.AllowSimultaneousConversations>

--- a/Languages/French/Keyed/Translation_French.xml
+++ b/Languages/French/Keyed/Translation_French.xml
@@ -181,7 +181,6 @@ Conseils Cruciaux :
     <RimTalk.Settings.EventFilter>Filtre d'événements</RimTalk.Settings.EventFilter>
     <RimTalk.Settings.ApiKey>Clé API Cloud</RimTalk.Settings.ApiKey>
     <RimTalk.Settings.GetFreeApiKey>Obtenir une clé API gratuite</RimTalk.Settings.GetFreeApiKey>
-    <RimTalk.Settings.AICooldown>Temps de recharge de l'IA (Secondes) : {0}</RimTalk.Settings.AICooldown>
     <RimTalk.Settings.LLMProcessInterval>Intervalle de traitement des TalkRequest par le LLM (secondes) : {0}</RimTalk.Settings.LLMProcessInterval>
     <RimTalk.Settings.AutoTalkRequestInterval>Intervalle de création automatique des TalkRequest (secondes) : {0}</RimTalk.Settings.AutoTalkRequestInterval>
     <RimTalk.Settings.TalkRequestQueueMax>Taille max de la file TalkRequest : {0}</RimTalk.Settings.TalkRequestQueueMax>

--- a/Languages/Japanese/Keyed/Translation_Japanese.xml
+++ b/Languages/Japanese/Keyed/Translation_Japanese.xml
@@ -181,7 +181,6 @@ Scribanマジック (動的コンテンツ)
     <RimTalk.Settings.EventFilter>イベントフィルター</RimTalk.Settings.EventFilter>
     <RimTalk.Settings.ApiKey>クラウドAPIキー</RimTalk.Settings.ApiKey>
     <RimTalk.Settings.GetFreeApiKey>無料APIキーを取得</RimTalk.Settings.GetFreeApiKey>
-    <RimTalk.Settings.AICooldown>AIクールダウン（秒）：{0}</RimTalk.Settings.AICooldown>
     <RimTalk.Settings.LLMProcessInterval>LLM の TalkRequest 処理間隔（秒）：{0}</RimTalk.Settings.LLMProcessInterval>
     <RimTalk.Settings.AutoTalkRequestInterval>TalkRequest 自動作成間隔（秒）：{0}</RimTalk.Settings.AutoTalkRequestInterval>
     <RimTalk.Settings.TalkRequestQueueMax>TalkRequest キュー最大数：{0}</RimTalk.Settings.TalkRequestQueueMax>

--- a/Languages/Japanese/Keyed/Translation_Japanese.xml
+++ b/Languages/Japanese/Keyed/Translation_Japanese.xml
@@ -190,16 +190,18 @@ Scribanマジック (動的コンテンツ)
     <RimTalk.Settings.ForceSpeakIgnored>待機後に無視された対話を強制表示</RimTalk.Settings.ForceSpeakIgnored>
     <RimTalk.Settings.ForceSpeakIgnoredTooltip>有効にすると、親行の無視によってブロックされた行は待機時間後に強制的に表示されます。</RimTalk.Settings.ForceSpeakIgnoredTooltip>
     <RimTalk.Settings.SpeakWhilePaused>一時停止中も発話を許可</RimTalk.Settings.SpeakWhilePaused>
-    <RimTalk.Settings.StopSpeakingInMenus>設定/デバッグ/対話ウィンドウ表示中は発話を停止</RimTalk.Settings.StopSpeakingInMenus>
-    <RimTalk.Settings.AdvancedMenuAvoidance>高度なメニュー回避（メインタブ、計画、研究など）</RimTalk.Settings.AdvancedMenuAvoidance>
-    <RimTalk.Settings.AlignTimingToNormalSpeed>全ゲーム速度で1倍速と同じタイミングを適用</RimTalk.Settings.AlignTimingToNormalSpeed>
-    <RimTalk.Settings.IgnorePendingHotkeyEnabled>保留中の対話をすべて無視するホットキーを有効化（Home）</RimTalk.Settings.IgnorePendingHotkeyEnabled>
+    <RimTalk.Settings.StopSpeakingInMenus>非 RimTalk の設定/デバッグ/対話ウィンドウ表示中は発話を停止</RimTalk.Settings.StopSpeakingInMenus>
+    <RimTalk.Settings.AdvancedMenuAvoidance>高度なウィンドウでは発話を停止（メインタブ、計画、研究など）</RimTalk.Settings.AdvancedMenuAvoidance>
+    <RimTalk.Settings.AlignTimingToNormalSpeed>対話を固定 60 tick/s（1x基準）で調度</RimTalk.Settings.AlignTimingToNormalSpeed>
+    <RimTalk.Settings.IgnorePendingHotkeyEnabled>保留中の対話をすべてスキップするホットキーを有効化</RimTalk.Settings.IgnorePendingHotkeyEnabled>
+    <RimTalk.Settings.IgnorePendingHotkey>保留中の対話を一括スキップするキー：</RimTalk.Settings.IgnorePendingHotkey>
     <RimTalk.Settings.ProcessUserTalkRequestImmediately>手動挿入したユーザー TalkRequest を即時処理</RimTalk.Settings.ProcessUserTalkRequestImmediately>
     <RimTalk.Settings.ProcessUserTalkRequestImmediatelyTooltip>有効にすると、ユーザー TalkRequest はユーザーキュー先頭に入り、毎tick処理判定されます。</RimTalk.Settings.ProcessUserTalkRequestImmediatelyTooltip>
     <RimTalk.Settings.DisplayUserTalkRequestImmediately>手動挿入したユーザー TalkRequest を即時表示</RimTalk.Settings.DisplayUserTalkRequestImmediately>
     <RimTalk.Settings.DisplayUserTalkRequestImmediatelyTooltip>有効にすると、ユーザー挿入の対話を表示する前に保留中の対話をすべて強制無視します。</RimTalk.Settings.DisplayUserTalkRequestImmediatelyTooltip>
     <RimTalk.Settings.IgnoreAllPendingNow>保留中の対話を今すぐすべて無視</RimTalk.Settings.IgnoreAllPendingNow>
     <RimTalk.Settings.IgnorePendingResult>RimTalk：保留中の対話 {0} 件を無視しました。</RimTalk.Settings.IgnorePendingResult>
+    <RimTalk.Settings.SkipPendingResult>RimTalk：キュー中の対話 {0} 件をスキップしました。</RimTalk.Settings.SkipPendingResult>
     <RimTalk.Settings.OverrideInteractions>すべてのインタラクションをAIの対話で上書きする</RimTalk.Settings.OverrideInteractions>
     <RimTalk.Settings.OverrideInteractionsTooltip>これを有効にすると、AIがすべてのインタラクション（バニラのRimWorldや他のMODを含む）の対話を上書きして再生成できるようになります。注意：AIの対話には上記で設定されたクールダウン期間があります。より頻繁に対話を生成するには、クールダウンを短くしてください。</RimTalk.Settings.OverrideInteractionsTooltip>
     <RimTalk.Settings.AllowSimultaneousConversations>複数の同時会話を許可</RimTalk.Settings.AllowSimultaneousConversations>

--- a/Languages/Japanese/Keyed/Translation_Japanese.xml
+++ b/Languages/Japanese/Keyed/Translation_Japanese.xml
@@ -182,6 +182,24 @@ Scribanマジック (動的コンテンツ)
     <RimTalk.Settings.ApiKey>クラウドAPIキー</RimTalk.Settings.ApiKey>
     <RimTalk.Settings.GetFreeApiKey>無料APIキーを取得</RimTalk.Settings.GetFreeApiKey>
     <RimTalk.Settings.AICooldown>AIクールダウン（秒）：{0}</RimTalk.Settings.AICooldown>
+    <RimTalk.Settings.LLMProcessInterval>LLM の TalkRequest 処理間隔（秒）：{0}</RimTalk.Settings.LLMProcessInterval>
+    <RimTalk.Settings.AutoTalkRequestInterval>TalkRequest 自動作成間隔（秒）：{0}</RimTalk.Settings.AutoTalkRequestInterval>
+    <RimTalk.Settings.TalkRequestQueueMax>TalkRequest キュー最大数：{0}</RimTalk.Settings.TalkRequestQueueMax>
+    <RimTalk.Settings.DisplayTalkInterval>対話表示間隔（秒）：{0}</RimTalk.Settings.DisplayTalkInterval>
+    <RimTalk.Settings.IgnoreWaitSeconds>無視チェーン待機時間（秒）：{0}</RimTalk.Settings.IgnoreWaitSeconds>
+    <RimTalk.Settings.ForceSpeakIgnored>待機後に無視された対話を強制表示</RimTalk.Settings.ForceSpeakIgnored>
+    <RimTalk.Settings.ForceSpeakIgnoredTooltip>有効にすると、親行の無視によってブロックされた行は待機時間後に強制的に表示されます。</RimTalk.Settings.ForceSpeakIgnoredTooltip>
+    <RimTalk.Settings.SpeakWhilePaused>一時停止中も発話を許可</RimTalk.Settings.SpeakWhilePaused>
+    <RimTalk.Settings.StopSpeakingInMenus>設定/デバッグ/対話ウィンドウ表示中は発話を停止</RimTalk.Settings.StopSpeakingInMenus>
+    <RimTalk.Settings.AdvancedMenuAvoidance>高度なメニュー回避（メインタブ、計画、研究など）</RimTalk.Settings.AdvancedMenuAvoidance>
+    <RimTalk.Settings.AlignTimingToNormalSpeed>全ゲーム速度で1倍速と同じタイミングを適用</RimTalk.Settings.AlignTimingToNormalSpeed>
+    <RimTalk.Settings.IgnorePendingHotkeyEnabled>保留中の対話をすべて無視するホットキーを有効化（Home）</RimTalk.Settings.IgnorePendingHotkeyEnabled>
+    <RimTalk.Settings.ProcessUserTalkRequestImmediately>手動挿入したユーザー TalkRequest を即時処理</RimTalk.Settings.ProcessUserTalkRequestImmediately>
+    <RimTalk.Settings.ProcessUserTalkRequestImmediatelyTooltip>有効にすると、ユーザー TalkRequest はユーザーキュー先頭に入り、毎tick処理判定されます。</RimTalk.Settings.ProcessUserTalkRequestImmediatelyTooltip>
+    <RimTalk.Settings.DisplayUserTalkRequestImmediately>手動挿入したユーザー TalkRequest を即時表示</RimTalk.Settings.DisplayUserTalkRequestImmediately>
+    <RimTalk.Settings.DisplayUserTalkRequestImmediatelyTooltip>有効にすると、ユーザー挿入の対話を表示する前に保留中の対話をすべて強制無視します。</RimTalk.Settings.DisplayUserTalkRequestImmediatelyTooltip>
+    <RimTalk.Settings.IgnoreAllPendingNow>保留中の対話を今すぐすべて無視</RimTalk.Settings.IgnoreAllPendingNow>
+    <RimTalk.Settings.IgnorePendingResult>RimTalk：保留中の対話 {0} 件を無視しました。</RimTalk.Settings.IgnorePendingResult>
     <RimTalk.Settings.OverrideInteractions>すべてのインタラクションをAIの対話で上書きする</RimTalk.Settings.OverrideInteractions>
     <RimTalk.Settings.OverrideInteractionsTooltip>これを有効にすると、AIがすべてのインタラクション（バニラのRimWorldや他のMODを含む）の対話を上書きして再生成できるようになります。注意：AIの対話には上記で設定されたクールダウン期間があります。より頻繁に対話を生成するには、クールダウンを短くしてください。</RimTalk.Settings.OverrideInteractionsTooltip>
     <RimTalk.Settings.AllowSimultaneousConversations>複数の同時会話を許可</RimTalk.Settings.AllowSimultaneousConversations>

--- a/Languages/Korean/Keyed/Translation_Korean.xml
+++ b/Languages/Korean/Keyed/Translation_Korean.xml
@@ -182,6 +182,24 @@ Scriban 매직 (동적 콘텐츠)
     <RimTalk.Settings.ApiKey>클라우드 API 키</RimTalk.Settings.ApiKey>
     <RimTalk.Settings.GetFreeApiKey>무료 API 키 받기</RimTalk.Settings.GetFreeApiKey>
     <RimTalk.Settings.AICooldown>AI 재사용 대기시간 (초): {0}</RimTalk.Settings.AICooldown>
+    <RimTalk.Settings.LLMProcessInterval>LLM TalkRequest 처리 간격 (초): {0}</RimTalk.Settings.LLMProcessInterval>
+    <RimTalk.Settings.AutoTalkRequestInterval>TalkRequest 자동 생성 간격 (초): {0}</RimTalk.Settings.AutoTalkRequestInterval>
+    <RimTalk.Settings.TalkRequestQueueMax>TalkRequest 큐 최대 개수: {0}</RimTalk.Settings.TalkRequestQueueMax>
+    <RimTalk.Settings.DisplayTalkInterval>대화 표시 간격 (초): {0}</RimTalk.Settings.DisplayTalkInterval>
+    <RimTalk.Settings.IgnoreWaitSeconds>무시 체인 대기 시간 (초): {0}</RimTalk.Settings.IgnoreWaitSeconds>
+    <RimTalk.Settings.ForceSpeakIgnored>대기 후 무시된 대화 강제 출력</RimTalk.Settings.ForceSpeakIgnored>
+    <RimTalk.Settings.ForceSpeakIgnoredTooltip>활성화하면 상위 대사가 무시되어 막힌 대화도 대기 시간 이후 강제로 출력됩니다.</RimTalk.Settings.ForceSpeakIgnoredTooltip>
+    <RimTalk.Settings.SpeakWhilePaused>일시정지 중에도 말하기 허용</RimTalk.Settings.SpeakWhilePaused>
+    <RimTalk.Settings.StopSpeakingInMenus>설정/디버그/대화 창이 열려 있으면 말하기 일시정지</RimTalk.Settings.StopSpeakingInMenus>
+    <RimTalk.Settings.AdvancedMenuAvoidance>고급 메뉴 회피 (메인 탭, 계획, 연구 등)</RimTalk.Settings.AdvancedMenuAvoidance>
+    <RimTalk.Settings.AlignTimingToNormalSpeed>모든 게임 속도에 1배속과 동일한 타이밍 적용</RimTalk.Settings.AlignTimingToNormalSpeed>
+    <RimTalk.Settings.IgnorePendingHotkeyEnabled>대기 중인 모든 대화 무시 단축키 활성화 (Home)</RimTalk.Settings.IgnorePendingHotkeyEnabled>
+    <RimTalk.Settings.ProcessUserTalkRequestImmediately>플레이어가 수동 삽입한 TalkRequest 즉시 처리</RimTalk.Settings.ProcessUserTalkRequestImmediately>
+    <RimTalk.Settings.ProcessUserTalkRequestImmediatelyTooltip>활성화하면 User TalkRequest를 사용자 큐 맨 앞으로 넣고 매 틱마다 처리 여부를 확인합니다.</RimTalk.Settings.ProcessUserTalkRequestImmediatelyTooltip>
+    <RimTalk.Settings.DisplayUserTalkRequestImmediately>플레이어가 수동 삽입한 TalkRequest 즉시 표시</RimTalk.Settings.DisplayUserTalkRequestImmediately>
+    <RimTalk.Settings.DisplayUserTalkRequestImmediatelyTooltip>활성화하면 사용자 삽입 대화를 표시하기 전에 대기 중인 모든 대화를 강제로 무시합니다.</RimTalk.Settings.DisplayUserTalkRequestImmediatelyTooltip>
+    <RimTalk.Settings.IgnoreAllPendingNow>대기 중인 모든 대화 즉시 무시</RimTalk.Settings.IgnoreAllPendingNow>
+    <RimTalk.Settings.IgnorePendingResult>RimTalk: 대기 중인 대화 {0}개를 무시했습니다.</RimTalk.Settings.IgnorePendingResult>
     <RimTalk.Settings.OverrideInteractions>모든 상호작용을 AI 대화로 덮어쓰기</RimTalk.Settings.OverrideInteractions>
     <RimTalk.Settings.OverrideInteractionsTooltip>이 옵션을 활성화하면 AI가 모든 상호작용(바닐라 림월드 및 다른 모드 포함)의 대화를 덮어쓰고 다시 생성할 수 있습니다. 참고: AI 대화에는 위에 설정된 재사용 대기시간이 있습니다. 대화를 더 자주 생성하려면 재사용 대기시간을 줄이세요.</RimTalk.Settings.OverrideInteractionsTooltip>
     <RimTalk.Settings.AllowSimultaneousConversations>동시다발적 대화 허용</RimTalk.Settings.AllowSimultaneousConversations>

--- a/Languages/Korean/Keyed/Translation_Korean.xml
+++ b/Languages/Korean/Keyed/Translation_Korean.xml
@@ -190,16 +190,18 @@ Scriban 매직 (동적 콘텐츠)
     <RimTalk.Settings.ForceSpeakIgnored>대기 후 무시된 대화 강제 출력</RimTalk.Settings.ForceSpeakIgnored>
     <RimTalk.Settings.ForceSpeakIgnoredTooltip>활성화하면 상위 대사가 무시되어 막힌 대화도 대기 시간 이후 강제로 출력됩니다.</RimTalk.Settings.ForceSpeakIgnoredTooltip>
     <RimTalk.Settings.SpeakWhilePaused>일시정지 중에도 말하기 허용</RimTalk.Settings.SpeakWhilePaused>
-    <RimTalk.Settings.StopSpeakingInMenus>설정/디버그/대화 창이 열려 있으면 말하기 일시정지</RimTalk.Settings.StopSpeakingInMenus>
-    <RimTalk.Settings.AdvancedMenuAvoidance>고급 메뉴 회피 (메인 탭, 계획, 연구 등)</RimTalk.Settings.AdvancedMenuAvoidance>
-    <RimTalk.Settings.AlignTimingToNormalSpeed>모든 게임 속도에 1배속과 동일한 타이밍 적용</RimTalk.Settings.AlignTimingToNormalSpeed>
-    <RimTalk.Settings.IgnorePendingHotkeyEnabled>대기 중인 모든 대화 무시 단축키 활성화 (Home)</RimTalk.Settings.IgnorePendingHotkeyEnabled>
+    <RimTalk.Settings.StopSpeakingInMenus>비 RimTalk 설정/디버그/대화 창이 열려 있으면 말하기 일시정지</RimTalk.Settings.StopSpeakingInMenus>
+    <RimTalk.Settings.AdvancedMenuAvoidance>고급 창에서 말하기 일시정지 (메인 탭, 계획, 연구 등)</RimTalk.Settings.AdvancedMenuAvoidance>
+    <RimTalk.Settings.AlignTimingToNormalSpeed>대화를 고정 60 tick/s(1배속 기준)로 스케줄</RimTalk.Settings.AlignTimingToNormalSpeed>
+    <RimTalk.Settings.IgnorePendingHotkeyEnabled>대기 중인 모든 대화 건너뛰기 단축키 활성화</RimTalk.Settings.IgnorePendingHotkeyEnabled>
+    <RimTalk.Settings.IgnorePendingHotkey>대기 대화 전체 건너뛰기 키:</RimTalk.Settings.IgnorePendingHotkey>
     <RimTalk.Settings.ProcessUserTalkRequestImmediately>플레이어가 수동 삽입한 TalkRequest 즉시 처리</RimTalk.Settings.ProcessUserTalkRequestImmediately>
     <RimTalk.Settings.ProcessUserTalkRequestImmediatelyTooltip>활성화하면 User TalkRequest를 사용자 큐 맨 앞으로 넣고 매 틱마다 처리 여부를 확인합니다.</RimTalk.Settings.ProcessUserTalkRequestImmediatelyTooltip>
     <RimTalk.Settings.DisplayUserTalkRequestImmediately>플레이어가 수동 삽입한 TalkRequest 즉시 표시</RimTalk.Settings.DisplayUserTalkRequestImmediately>
     <RimTalk.Settings.DisplayUserTalkRequestImmediatelyTooltip>활성화하면 사용자 삽입 대화를 표시하기 전에 대기 중인 모든 대화를 강제로 무시합니다.</RimTalk.Settings.DisplayUserTalkRequestImmediatelyTooltip>
     <RimTalk.Settings.IgnoreAllPendingNow>대기 중인 모든 대화 즉시 무시</RimTalk.Settings.IgnoreAllPendingNow>
     <RimTalk.Settings.IgnorePendingResult>RimTalk: 대기 중인 대화 {0}개를 무시했습니다.</RimTalk.Settings.IgnorePendingResult>
+    <RimTalk.Settings.SkipPendingResult>RimTalk: 큐에 쌓인 대화 {0}개를 건너뛰었습니다.</RimTalk.Settings.SkipPendingResult>
     <RimTalk.Settings.OverrideInteractions>모든 상호작용을 AI 대화로 덮어쓰기</RimTalk.Settings.OverrideInteractions>
     <RimTalk.Settings.OverrideInteractionsTooltip>이 옵션을 활성화하면 AI가 모든 상호작용(바닐라 림월드 및 다른 모드 포함)의 대화를 덮어쓰고 다시 생성할 수 있습니다. 참고: AI 대화에는 위에 설정된 재사용 대기시간이 있습니다. 대화를 더 자주 생성하려면 재사용 대기시간을 줄이세요.</RimTalk.Settings.OverrideInteractionsTooltip>
     <RimTalk.Settings.AllowSimultaneousConversations>동시다발적 대화 허용</RimTalk.Settings.AllowSimultaneousConversations>

--- a/Languages/Korean/Keyed/Translation_Korean.xml
+++ b/Languages/Korean/Keyed/Translation_Korean.xml
@@ -181,7 +181,6 @@ Scriban 매직 (동적 콘텐츠)
     <RimTalk.Settings.EventFilter>이벤트 필터</RimTalk.Settings.EventFilter>
     <RimTalk.Settings.ApiKey>클라우드 API 키</RimTalk.Settings.ApiKey>
     <RimTalk.Settings.GetFreeApiKey>무료 API 키 받기</RimTalk.Settings.GetFreeApiKey>
-    <RimTalk.Settings.AICooldown>AI 재사용 대기시간 (초): {0}</RimTalk.Settings.AICooldown>
     <RimTalk.Settings.LLMProcessInterval>LLM TalkRequest 처리 간격 (초): {0}</RimTalk.Settings.LLMProcessInterval>
     <RimTalk.Settings.AutoTalkRequestInterval>TalkRequest 자동 생성 간격 (초): {0}</RimTalk.Settings.AutoTalkRequestInterval>
     <RimTalk.Settings.TalkRequestQueueMax>TalkRequest 큐 최대 개수: {0}</RimTalk.Settings.TalkRequestQueueMax>

--- a/Languages/Russian/Keyed/Translation_Russian.xml
+++ b/Languages/Russian/Keyed/Translation_Russian.xml
@@ -180,7 +180,6 @@
     <RimTalk.Settings.EventFilter>Фильтр событий</RimTalk.Settings.EventFilter>
     <RimTalk.Settings.ApiKey>Ключ API облака</RimTalk.Settings.ApiKey>
     <RimTalk.Settings.GetFreeApiKey>Получить бесплатный ключ API</RimTalk.Settings.GetFreeApiKey>
-    <RimTalk.Settings.AICooldown>Время восстановления ИИ (секунды): {0}</RimTalk.Settings.AICooldown>
     <RimTalk.Settings.LLMProcessInterval>Интервал обработки TalkRequest LLM (секунды): {0}</RimTalk.Settings.LLMProcessInterval>
     <RimTalk.Settings.AutoTalkRequestInterval>Интервал авто-создания TalkRequest (секунды): {0}</RimTalk.Settings.AutoTalkRequestInterval>
     <RimTalk.Settings.TalkRequestQueueMax>Максимальный размер очереди TalkRequest: {0}</RimTalk.Settings.TalkRequestQueueMax>

--- a/Languages/Russian/Keyed/Translation_Russian.xml
+++ b/Languages/Russian/Keyed/Translation_Russian.xml
@@ -189,16 +189,18 @@
     <RimTalk.Settings.ForceSpeakIgnored>Принудительно показывать игнорируемые реплики после ожидания</RimTalk.Settings.ForceSpeakIgnored>
     <RimTalk.Settings.ForceSpeakIgnoredTooltip>Если включено, реплики, заблокированные из-за игнорируемой родительской строки, будут принудительно показаны после времени ожидания.</RimTalk.Settings.ForceSpeakIgnoredTooltip>
     <RimTalk.Settings.SpeakWhilePaused>Разрешить разговоры на паузе</RimTalk.Settings.SpeakWhilePaused>
-    <RimTalk.Settings.StopSpeakingInMenus>Приостанавливать разговоры при открытых окнах настроек/отладки/диалогов</RimTalk.Settings.StopSpeakingInMenus>
-    <RimTalk.Settings.AdvancedMenuAvoidance>Расширенное избегание меню (главные вкладки, планировщик, исследования и т.д.)</RimTalk.Settings.AdvancedMenuAvoidance>
-    <RimTalk.Settings.AlignTimingToNormalSpeed>Применять одинаковый тайминг как на скорости x1 для всех скоростей</RimTalk.Settings.AlignTimingToNormalSpeed>
-    <RimTalk.Settings.IgnorePendingHotkeyEnabled>Включить горячую клавишу игнорирования всех ожидающих диалогов (Home)</RimTalk.Settings.IgnorePendingHotkeyEnabled>
+    <RimTalk.Settings.StopSpeakingInMenus>Приостанавливать разговоры при открытых окнах настроек/отладки/диалогов не из RimTalk</RimTalk.Settings.StopSpeakingInMenus>
+    <RimTalk.Settings.AdvancedMenuAvoidance>Приостанавливать разговоры в расширенных окнах (главные вкладки, планировщик, исследования и т.д.)</RimTalk.Settings.AdvancedMenuAvoidance>
+    <RimTalk.Settings.AlignTimingToNormalSpeed>Планировать диалоги с фиксированной частотой 60 tick/s (база x1)</RimTalk.Settings.AlignTimingToNormalSpeed>
+    <RimTalk.Settings.IgnorePendingHotkeyEnabled>Включить горячую клавишу пропуска всех ожидающих диалогов</RimTalk.Settings.IgnorePendingHotkeyEnabled>
+    <RimTalk.Settings.IgnorePendingHotkey>Клавиша пропуска всех ожидающих диалогов:</RimTalk.Settings.IgnorePendingHotkey>
     <RimTalk.Settings.ProcessUserTalkRequestImmediately>Немедленно обрабатывать вручную вставленные пользовательские TalkRequest</RimTalk.Settings.ProcessUserTalkRequestImmediately>
     <RimTalk.Settings.ProcessUserTalkRequestImmediatelyTooltip>Если включено, пользовательские TalkRequest ставятся в начало пользовательской очереди и проверяются каждый тик.</RimTalk.Settings.ProcessUserTalkRequestImmediatelyTooltip>
     <RimTalk.Settings.DisplayUserTalkRequestImmediately>Немедленно отображать вручную вставленные пользовательские TalkRequest</RimTalk.Settings.DisplayUserTalkRequestImmediately>
     <RimTalk.Settings.DisplayUserTalkRequestImmediatelyTooltip>Если включено, перед показом пользовательского диалога все ожидающие реплики принудительно игнорируются.</RimTalk.Settings.DisplayUserTalkRequestImmediatelyTooltip>
     <RimTalk.Settings.IgnoreAllPendingNow>Игнорировать все ожидающие диалоги сейчас</RimTalk.Settings.IgnoreAllPendingNow>
     <RimTalk.Settings.IgnorePendingResult>RimTalk: Игнорировано ожидающих реплик: {0}.</RimTalk.Settings.IgnorePendingResult>
+    <RimTalk.Settings.SkipPendingResult>RimTalk: Пропущено реплик в очереди: {0}.</RimTalk.Settings.SkipPendingResult>
     <RimTalk.Settings.OverrideInteractions>Переопределять все взаимодействия диалогами ИИ</RimTalk.Settings.OverrideInteractions>
     <RimTalk.Settings.OverrideInteractionsTooltip>Включите, чтобы позволить ИИ переопределять и регенерировать диалоги для всех взаимодействий (включая ванильный RimWorld и другие моды). Примечание: диалоги ИИ имеют период восстановления, установленный выше. Чтобы генерировать диалоги чаще, уменьшите время восстановления.</RimTalk.Settings.OverrideInteractionsTooltip>
     <RimTalk.Settings.AllowSimultaneousConversations>Разрешить одновременные разговоры</RimTalk.Settings.AllowSimultaneousConversations>

--- a/Languages/Russian/Keyed/Translation_Russian.xml
+++ b/Languages/Russian/Keyed/Translation_Russian.xml
@@ -181,6 +181,24 @@
     <RimTalk.Settings.ApiKey>Ключ API облака</RimTalk.Settings.ApiKey>
     <RimTalk.Settings.GetFreeApiKey>Получить бесплатный ключ API</RimTalk.Settings.GetFreeApiKey>
     <RimTalk.Settings.AICooldown>Время восстановления ИИ (секунды): {0}</RimTalk.Settings.AICooldown>
+    <RimTalk.Settings.LLMProcessInterval>Интервал обработки TalkRequest LLM (секунды): {0}</RimTalk.Settings.LLMProcessInterval>
+    <RimTalk.Settings.AutoTalkRequestInterval>Интервал авто-создания TalkRequest (секунды): {0}</RimTalk.Settings.AutoTalkRequestInterval>
+    <RimTalk.Settings.TalkRequestQueueMax>Максимальный размер очереди TalkRequest: {0}</RimTalk.Settings.TalkRequestQueueMax>
+    <RimTalk.Settings.DisplayTalkInterval>Интервал показа диалогов (секунды): {0}</RimTalk.Settings.DisplayTalkInterval>
+    <RimTalk.Settings.IgnoreWaitSeconds>Время ожидания игнорируемой цепочки (секунды): {0}</RimTalk.Settings.IgnoreWaitSeconds>
+    <RimTalk.Settings.ForceSpeakIgnored>Принудительно показывать игнорируемые реплики после ожидания</RimTalk.Settings.ForceSpeakIgnored>
+    <RimTalk.Settings.ForceSpeakIgnoredTooltip>Если включено, реплики, заблокированные из-за игнорируемой родительской строки, будут принудительно показаны после времени ожидания.</RimTalk.Settings.ForceSpeakIgnoredTooltip>
+    <RimTalk.Settings.SpeakWhilePaused>Разрешить разговоры на паузе</RimTalk.Settings.SpeakWhilePaused>
+    <RimTalk.Settings.StopSpeakingInMenus>Приостанавливать разговоры при открытых окнах настроек/отладки/диалогов</RimTalk.Settings.StopSpeakingInMenus>
+    <RimTalk.Settings.AdvancedMenuAvoidance>Расширенное избегание меню (главные вкладки, планировщик, исследования и т.д.)</RimTalk.Settings.AdvancedMenuAvoidance>
+    <RimTalk.Settings.AlignTimingToNormalSpeed>Применять одинаковый тайминг как на скорости x1 для всех скоростей</RimTalk.Settings.AlignTimingToNormalSpeed>
+    <RimTalk.Settings.IgnorePendingHotkeyEnabled>Включить горячую клавишу игнорирования всех ожидающих диалогов (Home)</RimTalk.Settings.IgnorePendingHotkeyEnabled>
+    <RimTalk.Settings.ProcessUserTalkRequestImmediately>Немедленно обрабатывать вручную вставленные пользовательские TalkRequest</RimTalk.Settings.ProcessUserTalkRequestImmediately>
+    <RimTalk.Settings.ProcessUserTalkRequestImmediatelyTooltip>Если включено, пользовательские TalkRequest ставятся в начало пользовательской очереди и проверяются каждый тик.</RimTalk.Settings.ProcessUserTalkRequestImmediatelyTooltip>
+    <RimTalk.Settings.DisplayUserTalkRequestImmediately>Немедленно отображать вручную вставленные пользовательские TalkRequest</RimTalk.Settings.DisplayUserTalkRequestImmediately>
+    <RimTalk.Settings.DisplayUserTalkRequestImmediatelyTooltip>Если включено, перед показом пользовательского диалога все ожидающие реплики принудительно игнорируются.</RimTalk.Settings.DisplayUserTalkRequestImmediatelyTooltip>
+    <RimTalk.Settings.IgnoreAllPendingNow>Игнорировать все ожидающие диалоги сейчас</RimTalk.Settings.IgnoreAllPendingNow>
+    <RimTalk.Settings.IgnorePendingResult>RimTalk: Игнорировано ожидающих реплик: {0}.</RimTalk.Settings.IgnorePendingResult>
     <RimTalk.Settings.OverrideInteractions>Переопределять все взаимодействия диалогами ИИ</RimTalk.Settings.OverrideInteractions>
     <RimTalk.Settings.OverrideInteractionsTooltip>Включите, чтобы позволить ИИ переопределять и регенерировать диалоги для всех взаимодействий (включая ванильный RimWorld и другие моды). Примечание: диалоги ИИ имеют период восстановления, установленный выше. Чтобы генерировать диалоги чаще, уменьшите время восстановления.</RimTalk.Settings.OverrideInteractionsTooltip>
     <RimTalk.Settings.AllowSimultaneousConversations>Разрешить одновременные разговоры</RimTalk.Settings.AllowSimultaneousConversations>

--- a/Source/Data/PawnState.cs
+++ b/Source/Data/PawnState.cs
@@ -25,6 +25,8 @@ public class PawnState(Pawn pawn)
 
     public void AddTalkRequest(string prompt, Pawn recipient = null, TalkType talkType = TalkType.Other)
     {
+        TrimTalkRequestQueueIfNeeded();
+
         // 1. If Urgent, clear out less important active requests
         if (talkType == TalkType.Urgent)
         {
@@ -49,10 +51,17 @@ public class PawnState(Pawn pawn)
 
         if (talkType.IsFromUser())
         {
+            var settings = Settings.Get();
             TalkRequests.AddFirst(newRequest);
-            IgnoreAllTalkResponses();
-            Cache.Get(recipient)?.IgnoreAllTalkResponses();
-            UserRequestPool.Add(Pawn);
+
+            // Optional "immediate display": clear all already-pending lines before user-inserted dialogue.
+            if (settings.DisplayUserTalkRequestImmediately)
+            {
+                foreach (var state in Cache.GetAll())
+                    state.IgnoreAllTalkResponses();
+            }
+
+            UserRequestPool.Add(Pawn, settings.ProcessUserTalkRequestImmediately);
         }
         else if (talkType is TalkType.Event or TalkType.QuestOffer)
         {
@@ -106,8 +115,9 @@ public class PawnState(Pawn pawn)
     public bool CanGenerateTalk()
     {
         if (Pawn.IsPlayer()) return true;
+        var settings = Settings.Get();
         return !IsGeneratingTalk && CanDisplayTalk() && Pawn.Awake() && TalkResponses.Empty() 
-               && CommonUtil.HasPassed(LastTalkTick, RimTalkSettings.ReplyInterval);
+               && CommonUtil.HasPassed(LastTalkTick, settings.TalkInterval, settings.AlignTimingToNormalSpeed);
     }
     
     public void IgnoreTalkResponse()
@@ -133,5 +143,32 @@ public class PawnState(Pawn pawn)
                 TalkHistory.AddIgnored(response.Id);
                 return true;
             });
+    }
+
+    private void TrimTalkRequestQueueIfNeeded()
+    {
+        int maxQueueSize = Settings.Get().MaxTalkRequestQueueSize;
+        if (maxQueueSize < 1) maxQueueSize = 1;
+
+        while (TalkRequests.Count >= maxQueueSize)
+        {
+            var removable = FindFirstNonUserRequestNode() ?? TalkRequests.Last;
+            if (removable == null) break;
+
+            TalkRequestPool.AddToHistory(removable.Value, RequestStatus.Expired);
+            TalkRequests.Remove(removable);
+        }
+    }
+
+    private LinkedListNode<TalkRequest> FindFirstNonUserRequestNode()
+    {
+        var node = TalkRequests.First;
+        while (node != null)
+        {
+            if (!node.Value.TalkType.IsFromUser())
+                return node;
+            node = node.Next;
+        }
+        return null;
     }
 }

--- a/Source/Data/TalkRequestPool.cs
+++ b/Source/Data/TalkRequestPool.cs
@@ -20,6 +20,7 @@ public static class TalkRequestPool
             Status = RequestStatus.Pending
         };
         Requests.Add(request);
+        TrimRequestQueueIfNeeded();
     }
 
     public static TalkRequest GetRequestFromPool(Pawn pawn)
@@ -84,4 +85,17 @@ public static class TalkRequestPool
 
     public static int Count => Requests.Count;
     public static bool IsEmpty => Requests.Count == 0;
+
+    private static void TrimRequestQueueIfNeeded()
+    {
+        int maxQueueSize = Settings.Get().MaxTalkRequestQueueSize;
+        if (maxQueueSize < 1) maxQueueSize = 1;
+
+        while (Requests.Count > maxQueueSize)
+        {
+            var oldest = Requests[0];
+            AddToHistory(oldest, RequestStatus.Expired);
+            Requests.RemoveAt(0);
+        }
+    }
 }

--- a/Source/Data/UserRequestPool.cs
+++ b/Source/Data/UserRequestPool.cs
@@ -9,6 +9,11 @@ public class UserRequestPool
 
     public static void Add(Pawn pawn, bool priority = false)
     {
+        if (pawn == null) return;
+
+        // Keep one slot per pawn so "priority insert" always behaves deterministically.
+        UserRequests.Remove(pawn);
+
         if (priority)
             UserRequests.Insert(0, pawn);
         else

--- a/Source/Patch/TickManagerPatch.cs
+++ b/Source/Patch/TickManagerPatch.cs
@@ -11,14 +11,14 @@ namespace RimTalk.Patch;
 [HarmonyPatch(typeof(TickManager), nameof(TickManager.DoSingleTick))]
 internal static class TickManagerPatch
 {
-    private const double DisplayInterval = 0.5; // Display every half second
     private const double DebugStatUpdateInterval = 1;
     private const int UpdateCacheInterval = 5; // 5 seconds
-    private static double TalkInterval => Settings.Get().TalkInterval;
     private static bool _noApiKeyMessageShown;
     private static bool _initialCacheRefresh;
     private static bool _chatHistoryCleared;
     private static int _lastTalkEndTick;
+    private static int _lastDisplayTick;
+    private static int _lastAutoTalkCreateTick;
 
     public static void Postfix()
     {
@@ -29,7 +29,8 @@ internal static class TickManagerPatch
             Stats.Update();
         }
 
-        if (!Settings.Get().IsEnabled || Find.CurrentMap == null)
+        var settings = Settings.Get();
+        if (!settings.IsEnabled || Find.CurrentMap == null)
         {
             return;
         }
@@ -55,22 +56,23 @@ internal static class TickManagerPatch
             }
         }
 
-        if (!_noApiKeyMessageShown && Settings.Get().GetActiveConfig() == null)
+        if (!_noApiKeyMessageShown && settings.GetActiveConfig() == null)
         {
             Messages.Message("RimTalk.TickManager.ApiKeyMissing".Translate(), MessageTypeDefOf.NegativeEvent,
                 false);
             _noApiKeyMessageShown = true;
         }
 
-        if (IsNow(DisplayInterval))
+        if (ShouldRunDisplayTick())
         {
             CustomDialogueService.Tick();
             TalkService.DisplayTalk();
         }
 
-        if (IsNow(1))
+        bool shouldProcessUserRequestNow = settings.ProcessUserTalkRequestImmediately || IsNow(1);
+        if (shouldProcessUserRequestNow)
         {
-            // User-initiated talks are checked every second
+            // User-initiated talks: default is 1s cadence; optional immediate mode checks every tick.
             while (UserRequestPool.GetNextUserRequest() is { } pawn)
             {
                 var pawnState = Cache.Get(pawn);
@@ -87,7 +89,11 @@ internal static class TickManagerPatch
                     continue;
                 }
 
-                if (!request.TalkType.IsFromUser()) break;
+                if (!request.TalkType.IsFromUser())
+                {
+                    UserRequestPool.Remove(pawn);
+                    continue;
+                }
 
                 if (TalkService.GenerateTalk(request))
                     UserRequestPool.Remove(pawn);
@@ -101,7 +107,7 @@ internal static class TickManagerPatch
             return;
         }
 
-        int intervalTicks = CommonUtil.GetTicksForDuration(TalkInterval);
+        int intervalTicks = CommonUtil.GetTicksForDuration(settings.TalkInterval, settings.AlignTimingToNormalSpeed);
         if (intervalTicks > 0 && GenTicks.TicksGame - _lastTalkEndTick >= intervalTicks)
         {
             // Select a pawn based on the current iteration strategy
@@ -121,10 +127,12 @@ internal static class TickManagerPatch
                 }
 
                 // 3. Fallback: generate based on current context if nothing else worked
-                if (!talkGenerated)
+                if (!talkGenerated && CanCreateAutoTalkRequestNow())
                 {
                     TalkRequest talkRequest = new TalkRequest(null, selectedPawn);
-                    TalkService.GenerateTalk(talkRequest);
+                    talkGenerated = TalkService.GenerateTalk(talkRequest);
+                    if (talkGenerated)
+                        _lastAutoTalkCreateTick = GenTicks.TicksGame;
                 }
             }
             
@@ -147,10 +155,30 @@ internal static class TickManagerPatch
         return Counter.Tick % ticksForDuration == 0;
     }
 
+    private static bool ShouldRunDisplayTick()
+    {
+        var settings = Settings.Get();
+        int intervalTicks = CommonUtil.GetTicksForDuration(settings.DisplayTalkInterval, settings.AlignTimingToNormalSpeed);
+        if (intervalTicks <= 0) return false;
+        if (GenTicks.TicksGame - _lastDisplayTick < intervalTicks) return false;
+        _lastDisplayTick = GenTicks.TicksGame;
+        return true;
+    }
+
+    private static bool CanCreateAutoTalkRequestNow()
+    {
+        var settings = Settings.Get();
+        int intervalTicks = CommonUtil.GetTicksForDuration(settings.AutoTalkRequestInterval, settings.AlignTimingToNormalSpeed);
+        if (intervalTicks <= 0) return true;
+        return GenTicks.TicksGame - _lastAutoTalkCreateTick >= intervalTicks;
+    }
+
     public static void Reset()
     {
         _noApiKeyMessageShown = false;
         _initialCacheRefresh = false;
         _lastTalkEndTick = GenTicks.TicksGame;
+        _lastDisplayTick = GenTicks.TicksGame;
+        _lastAutoTalkCreateTick = GenTicks.TicksGame;
     }
 }

--- a/Source/Patch/UIRootPlayPatch.cs
+++ b/Source/Patch/UIRootPlayPatch.cs
@@ -1,0 +1,40 @@
+using HarmonyLib;
+using RimTalk.Service;
+using RimWorld;
+using UnityEngine;
+using Verse;
+
+namespace RimTalk.Patch;
+
+[HarmonyPriority(Priority.First)]
+[HarmonyPatch(typeof(UIRoot_Play), nameof(UIRoot_Play.UIRootUpdate))]
+internal static class UIRootPlayPatch
+{
+    private static float _lastPausedDisplayTime;
+
+    public static void Postfix()
+    {
+        var settings = Settings.Get();
+        if (!settings.IsEnabled) return;
+
+        if (settings.IgnorePendingHotkeyEnabled && Input.GetKeyDown(settings.IgnorePendingHotkey))
+        {
+            int ignored = TalkService.IgnoreAllPendingTalks();
+            Messages.Message("RimTalk.Settings.IgnorePendingResult".Translate(ignored), MessageTypeDefOf.CautionInput, false);
+        }
+
+        if (!Find.TickManager.Paused || !settings.SpeakWhilePaused) return;
+        if (settings.StopSpeakingInMenus && TalkService.IsSpeakingBlockedByMenu(settings.AdvancedMenuAvoidance)) return;
+
+        float now = Time.realtimeSinceStartup;
+        if (now - _lastPausedDisplayTime < settings.DisplayTalkInterval) return;
+        _lastPausedDisplayTime = now;
+
+        TalkService.DisplayTalk();
+    }
+
+    public static void Reset()
+    {
+        _lastPausedDisplayTime = 0f;
+    }
+}

--- a/Source/Patch/UIRootPlayPatch.cs
+++ b/Source/Patch/UIRootPlayPatch.cs
@@ -19,12 +19,11 @@ internal static class UIRootPlayPatch
 
         if (settings.IgnorePendingHotkeyEnabled && Input.GetKeyDown(settings.IgnorePendingHotkey))
         {
-            int ignored = TalkService.IgnoreAllPendingTalks();
-            Messages.Message("RimTalk.Settings.IgnorePendingResult".Translate(ignored), MessageTypeDefOf.CautionInput, false);
+            int cleared = TalkService.ClearAllPendingTalksForce();
+            Messages.Message("RimTalk.Settings.SkipPendingResult".Translate(cleared), MessageTypeDefOf.CautionInput, false);
         }
 
         if (!Find.TickManager.Paused || !settings.SpeakWhilePaused) return;
-        if (settings.StopSpeakingInMenus && TalkService.IsSpeakingBlockedByMenu(settings.AdvancedMenuAvoidance)) return;
 
         float now = Time.realtimeSinceStartup;
         if (now - _lastPausedDisplayTime < settings.DisplayTalkInterval) return;

--- a/Source/RimTalk.cs
+++ b/Source/RimTalk.cs
@@ -36,6 +36,7 @@ public class RimTalk : GameComponent
 
         AIErrorHandler.ResetQuotaWarning();
         TickManagerPatch.Reset();
+        UIRootPlayPatch.Reset();
         AIClientFactory.Clear();
         AIService.Clear();
         TalkHistory.Clear();

--- a/Source/Service/TalkService.cs
+++ b/Source/Service/TalkService.cs
@@ -164,6 +164,10 @@ public static class TalkService
     public static void DisplayTalk()
     {
         var settings = Settings.Get();
+        
+        // Keep menu-blocking and pause behavior consistent across all call paths.
+        if (Find.TickManager.Paused && !settings.SpeakWhilePaused) return;
+        if (settings.StopSpeakingInMenus && IsSpeakingBlockedByMenu(settings.AdvancedMenuAvoidance)) return;
 
         foreach (Pawn pawn in Cache.Keys)
         {
@@ -194,27 +198,19 @@ public static class TalkService
                 pawnState.IgnoreAllTalkResponses([TalkType.Urgent, TalkType.User]);
             }
 
-            bool parentIgnored = TalkHistory.IsTalkIgnored(talk.ParentTalkId);
-            bool forceSpeakIgnored = false;
-            if (parentIgnored)
+            int parentTalkTick = TalkHistory.GetSpokenTick(talk.ParentTalkId);
+            bool isWaiting = parentTalkTick == -1 ||
+                             !CommonUtil.HasPassed(parentTalkTick, replyInterval, settings.AlignTimingToNormalSpeed);
+            if (isWaiting)
             {
                 if (!HasWaitedLongEnough(apiLog, settings.IgnoreWaitSeconds)) continue;
-                
-                if (settings.ForceSpeakIgnored)
-                {
-                    forceSpeakIgnored = true;
-                }
-                else
+
+                if (!settings.ForceSpeakIgnored)
                 {
                     pawnState.IgnoreTalkResponse();
                     continue;
                 }
             }
-
-            // Enforce a delay for replies to make conversations feel more natural.
-            int parentTalkTick = TalkHistory.GetSpokenTick(talk.ParentTalkId);
-            if (!forceSpeakIgnored && (parentTalkTick == -1 || !CommonUtil.HasPassed(parentTalkTick, replyInterval, settings.AlignTimingToNormalSpeed)))
-                continue;
 
             CreateInteraction(pawn, talk);
             MarkAsSpokenForScheduling(talk, apiLog);
@@ -301,8 +297,8 @@ public static class TalkService
 
     private static bool ShouldDropUndisplayable(ApiLog apiLog, int waitSeconds)
     {
-        // Keep waiting longer than parent-ignore wait, then drop stale lines that can never display.
-        int dropAfterSeconds = Math.Max(waitSeconds * 2, 20);
+        // Drop stale lines for non-displayable pawns using a tighter cap derived from ignore-wait.
+        int dropAfterSeconds = Math.Min(waitSeconds * 2, 20);
         return apiLog != null && (DateTime.Now - apiLog.Timestamp).TotalSeconds >= dropAfterSeconds;
     }
 
@@ -327,6 +323,19 @@ public static class TalkService
             }
         }
         return ignoredCount;
+    }
+    
+    public static int ClearAllPendingTalksForce()
+    {
+        int clearedCount = 0;
+        foreach (var pawnState in Cache.GetAll())
+        {
+            if (pawnState == null) continue;
+            clearedCount += pawnState.TalkResponses.Count;
+            pawnState.TalkResponses.Clear();
+        }
+        Overlay.NotifyLogUpdated();
+        return clearedCount;
     }
 
     public static bool IsSpeakingBlockedByMenu(bool advancedMenuAvoidance)

--- a/Source/Service/TalkService.cs
+++ b/Source/Service/TalkService.cs
@@ -331,7 +331,13 @@ public static class TalkService
         foreach (var pawnState in Cache.GetAll())
         {
             if (pawnState == null) continue;
-            clearedCount += pawnState.TalkResponses.Count;
+            foreach (var response in pawnState.TalkResponses)
+            {
+                TalkHistory.AddIgnored(response.Id);
+                var log = ApiHistory.GetApiLog(response.Id);
+                if (log != null) log.SpokenTick = -1;
+                clearedCount++;
+            }
             pawnState.TalkResponses.Clear();
         }
         Overlay.NotifyLogUpdated();

--- a/Source/Service/TalkService.cs
+++ b/Source/Service/TalkService.cs
@@ -163,6 +163,8 @@ public static class TalkService
     /// </summary>
     public static void DisplayTalk()
     {
+        var settings = Settings.Get();
+
         foreach (Pawn pawn in Cache.Keys)
         {
             PawnState pawnState = Cache.Get(pawn);
@@ -175,25 +177,47 @@ public static class TalkService
                 continue;
             }
 
-            // Skip this talk if its parent was ignored or the pawn is currently unable to speak.
-            if (TalkHistory.IsTalkIgnored(talk.ParentTalkId) || !pawnState.CanDisplayTalk())
+            var apiLog = ApiHistory.GetApiLog(talk.Id);
+
+            // Temporary display blocking (drafted/sleeping/off-map) should not immediately delete queued speech.
+            if (!pawnState.CanDisplayTalk())
             {
-                pawnState.IgnoreTalkResponse();
+                if (ShouldDropUndisplayable(apiLog, settings.IgnoreWaitSeconds))
+                    pawnState.IgnoreTalkResponse();
                 continue;
             }
 
-            int replyInterval = RimTalkSettings.ReplyInterval;
+            double replyInterval = settings.DisplayTalkInterval;
             if (pawn.IsInDanger())
             {
-                replyInterval = 2;
+                replyInterval = Math.Min(replyInterval, 2);
                 pawnState.IgnoreAllTalkResponses([TalkType.Urgent, TalkType.User]);
+            }
+
+            bool parentIgnored = TalkHistory.IsTalkIgnored(talk.ParentTalkId);
+            bool forceSpeakIgnored = false;
+            if (parentIgnored)
+            {
+                if (!HasWaitedLongEnough(apiLog, settings.IgnoreWaitSeconds)) continue;
+                
+                if (settings.ForceSpeakIgnored)
+                {
+                    forceSpeakIgnored = true;
+                }
+                else
+                {
+                    pawnState.IgnoreTalkResponse();
+                    continue;
+                }
             }
 
             // Enforce a delay for replies to make conversations feel more natural.
             int parentTalkTick = TalkHistory.GetSpokenTick(talk.ParentTalkId);
-            if (parentTalkTick == -1 || !CommonUtil.HasPassed(parentTalkTick, replyInterval)) continue;
+            if (!forceSpeakIgnored && (parentTalkTick == -1 || !CommonUtil.HasPassed(parentTalkTick, replyInterval, settings.AlignTimingToNormalSpeed)))
+                continue;
 
             CreateInteraction(pawn, talk);
+            MarkAsSpokenForScheduling(talk, apiLog);
             
             break; // Display only one talk per tick to prevent overwhelming the screen.
         }
@@ -268,5 +292,63 @@ public static class TalkService
     private static bool AnyPawnHasPendingResponses()
     {
         return Cache.GetAll().Any(pawnState => pawnState.TalkResponses.Count > 0);
+    }
+
+    private static bool HasWaitedLongEnough(ApiLog apiLog, int waitSeconds)
+    {
+        return apiLog != null && (DateTime.Now - apiLog.Timestamp).TotalSeconds >= waitSeconds;
+    }
+
+    private static bool ShouldDropUndisplayable(ApiLog apiLog, int waitSeconds)
+    {
+        // Keep waiting longer than parent-ignore wait, then drop stale lines that can never display.
+        int dropAfterSeconds = Math.Max(waitSeconds * 2, 20);
+        return apiLog != null && (DateTime.Now - apiLog.Timestamp).TotalSeconds >= dropAfterSeconds;
+    }
+
+    private static void MarkAsSpokenForScheduling(TalkResponse talk, ApiLog apiLog)
+    {
+        TalkHistory.AddSpoken(talk.Id);
+        if (apiLog != null)
+            apiLog.SpokenTick = GenTicks.TicksGame;
+        Overlay.NotifyLogUpdated();
+    }
+
+    public static int IgnoreAllPendingTalks()
+    {
+        int ignoredCount = 0;
+        foreach (var pawnState in Cache.GetAll())
+        {
+            if (pawnState == null) continue;
+            while (pawnState.TalkResponses.Count > 0)
+            {
+                pawnState.IgnoreTalkResponse();
+                ignoredCount++;
+            }
+        }
+        return ignoredCount;
+    }
+
+    public static bool IsSpeakingBlockedByMenu(bool advancedMenuAvoidance)
+    {
+        WindowStack windowStack = Find.WindowStack;
+        if (windowStack == null) return false;
+
+        foreach (Window window in windowStack.Windows)
+        {
+            if (window.layer == WindowLayer.Dialog)
+            {
+                Type type = window.GetType();
+                string ns = type.Namespace;
+                string name = type.Name;
+                if (ns == null || !ns.StartsWith("RimTalk") || (advancedMenuAvoidance && name == "CustomDialogueWindow"))
+                    return true;
+            }
+            else if (advancedMenuAvoidance && !(window is MainTabWindow_Inspect) && window is MainTabWindow)
+            {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/Source/Settings/RimTalkSettings.cs
+++ b/Source/Settings/RimTalkSettings.cs
@@ -18,7 +18,21 @@ public class RimTalkSettings : ModSettings
     public string SimpleApiKey = "";
     public bool IsUsingFallbackModel = false;
     public bool IsEnabled = true;
+    // Legacy "AI cooldown" field: now interpreted as LLM processing interval
     public int TalkInterval = 7;
+    public int AutoTalkRequestInterval = 7;
+    public int MaxTalkRequestQueueSize = 20;
+    public float DisplayTalkInterval = 0.5f;
+    public int IgnoreWaitSeconds = 6;
+    public bool ForceSpeakIgnored = false;
+    public bool IgnorePendingHotkeyEnabled = true;
+    public KeyCode IgnorePendingHotkey = KeyCode.Home;
+    public bool ProcessUserTalkRequestImmediately = false;
+    public bool DisplayUserTalkRequestImmediately = true;
+    public bool SpeakWhilePaused = false;
+    public bool StopSpeakingInMenus = false;
+    public bool AdvancedMenuAvoidance = false;
+    public bool AlignTimingToNormalSpeed = false;
     public const int ReplyInterval = 4;
     public bool ProcessNonRimTalkInteractions = true;
     public bool AllowSimultaneousConversations = false;
@@ -166,6 +180,19 @@ public class RimTalkSettings : ModSettings
         Scribe_Values.Look(ref SimpleApiKey, "simpleApiKey", "");
         Scribe_Values.Look(ref IsEnabled, "isEnabled", true);
         Scribe_Values.Look(ref TalkInterval, "talkInterval", 7);
+        Scribe_Values.Look(ref AutoTalkRequestInterval, "autoTalkRequestInterval", 7);
+        Scribe_Values.Look(ref MaxTalkRequestQueueSize, "maxTalkRequestQueueSize", 20);
+        Scribe_Values.Look(ref DisplayTalkInterval, "displayTalkInterval", 0.5f);
+        Scribe_Values.Look(ref IgnoreWaitSeconds, "ignoreWaitSeconds", 6);
+        Scribe_Values.Look(ref ForceSpeakIgnored, "forceSpeakIgnored", false);
+        Scribe_Values.Look(ref IgnorePendingHotkeyEnabled, "ignorePendingHotkeyEnabled", true);
+        Scribe_Values.Look(ref IgnorePendingHotkey, "ignorePendingHotkey", KeyCode.Home);
+        Scribe_Values.Look(ref ProcessUserTalkRequestImmediately, "processUserTalkRequestImmediately", false);
+        Scribe_Values.Look(ref DisplayUserTalkRequestImmediately, "displayUserTalkRequestImmediately", true);
+        Scribe_Values.Look(ref SpeakWhilePaused, "speakWhilePaused", false);
+        Scribe_Values.Look(ref StopSpeakingInMenus, "stopSpeakingInMenus", false);
+        Scribe_Values.Look(ref AdvancedMenuAvoidance, "advancedMenuAvoidance", false);
+        Scribe_Values.Look(ref AlignTimingToNormalSpeed, "alignTimingToNormalSpeed", false);
         Scribe_Values.Look(ref ProcessNonRimTalkInteractions, "processNonRimTalkInteractions", true);
         Scribe_Values.Look(ref AllowSimultaneousConversations, "allowSimultaneousConversations", false);
         Scribe_Values.Look(ref DisplayTalkWhenDrafted, "displayTalkWhenDrafted", true);
@@ -305,6 +332,13 @@ public class RimTalkSettings : ModSettings
         {
             CloudConfigs.Add(new ApiConfig());
         }
+
+        // Clamp runtime scheduling values to safe bounds.
+        TalkInterval = Mathf.Clamp(TalkInterval, 1, 120);
+        AutoTalkRequestInterval = Mathf.Clamp(AutoTalkRequestInterval, 1, 120);
+        MaxTalkRequestQueueSize = Mathf.Clamp(MaxTalkRequestQueueSize, 1, 200);
+        DisplayTalkInterval = Mathf.Clamp(DisplayTalkInterval, 0.1f, 10f);
+        IgnoreWaitSeconds = Mathf.Clamp(IgnoreWaitSeconds, 1, 120);
     }
 
     private static PromptEntry GetOrCreateBaseInstructionEntry(PromptPreset preset)

--- a/Source/Settings/Settings_Basic.cs
+++ b/Source/Settings/Settings_Basic.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using RimTalk.Service;
+using RimWorld;
 using UnityEngine;
 using Verse;
 
@@ -58,11 +60,87 @@ public partial class Settings
 
         listingStandard.Gap(30f);
 
-        // AI Cooldown
-        var cooldownLabel = "RimTalk.Settings.AICooldown".Translate(settings.TalkInterval).ToString();
+        // LLM processing interval (replaces old AI cooldown semantics)
+        var cooldownLabel = "RimTalk.Settings.LLMProcessInterval".Translate(settings.TalkInterval).ToString();
         var cooldownLabelRect = listingStandard.GetRect(Text.CalcHeight(cooldownLabel, listingStandard.ColumnWidth));
         Widgets.Label(cooldownLabelRect, cooldownLabel);
         settings.TalkInterval = (int)listingStandard.Slider(settings.TalkInterval, 1, 60);
+
+        // Auto TalkRequest creation interval (non-event fallback generation)
+        string autoCreateLabel = "RimTalk.Settings.AutoTalkRequestInterval".Translate(settings.AutoTalkRequestInterval).ToString();
+        var autoCreateRect = listingStandard.GetRect(Text.CalcHeight(autoCreateLabel, listingStandard.ColumnWidth));
+        Widgets.Label(autoCreateRect, autoCreateLabel);
+        settings.AutoTalkRequestInterval = (int)listingStandard.Slider(settings.AutoTalkRequestInterval, 1, 60);
+
+        // Max TalkRequest queue size
+        string queueLabel = "RimTalk.Settings.TalkRequestQueueMax".Translate(settings.MaxTalkRequestQueueSize).ToString();
+        var queueRect = listingStandard.GetRect(Text.CalcHeight(queueLabel, listingStandard.ColumnWidth));
+        Widgets.Label(queueRect, queueLabel);
+        settings.MaxTalkRequestQueueSize = (int)listingStandard.Slider(settings.MaxTalkRequestQueueSize, 1, 100);
+
+        // Dialogue display interval
+        string displayLabel = "RimTalk.Settings.DisplayTalkInterval".Translate(settings.DisplayTalkInterval.ToString("F1")).ToString();
+        var displayRect = listingStandard.GetRect(Text.CalcHeight(displayLabel, listingStandard.ColumnWidth));
+        Widgets.Label(displayRect, displayLabel);
+        settings.DisplayTalkInterval = (float)Math.Round(listingStandard.Slider(settings.DisplayTalkInterval, 0.1f, 10f) * 10f) / 10f;
+
+        // Ignore wait time for parent-chain break protection
+        string ignoreWaitLabel = "RimTalk.Settings.IgnoreWaitSeconds".Translate(settings.IgnoreWaitSeconds).ToString();
+        var ignoreWaitRect = listingStandard.GetRect(Text.CalcHeight(ignoreWaitLabel, listingStandard.ColumnWidth));
+        Widgets.Label(ignoreWaitRect, ignoreWaitLabel);
+        settings.IgnoreWaitSeconds = (int)listingStandard.Slider(settings.IgnoreWaitSeconds, 1, 30);
+
+        listingStandard.CheckboxLabeled(
+            "RimTalk.Settings.ForceSpeakIgnored".Translate().ToString(),
+            ref settings.ForceSpeakIgnored,
+            "RimTalk.Settings.ForceSpeakIgnoredTooltip".Translate().ToString()
+        );
+        listingStandard.Gap(4f);
+        listingStandard.CheckboxLabeled(
+            "RimTalk.Settings.SpeakWhilePaused".Translate().ToString(),
+            ref settings.SpeakWhilePaused
+        );
+        listingStandard.Gap(4f);
+        listingStandard.CheckboxLabeled(
+            "RimTalk.Settings.StopSpeakingInMenus".Translate().ToString(),
+            ref settings.StopSpeakingInMenus
+        );
+        if (settings.StopSpeakingInMenus)
+        {
+            listingStandard.Gap(2f);
+            listingStandard.CheckboxLabeled(
+                "RimTalk.Settings.AdvancedMenuAvoidance".Translate().ToString(),
+                ref settings.AdvancedMenuAvoidance
+            );
+        }
+        listingStandard.Gap(4f);
+        listingStandard.CheckboxLabeled(
+            "RimTalk.Settings.AlignTimingToNormalSpeed".Translate().ToString(),
+            ref settings.AlignTimingToNormalSpeed
+        );
+        listingStandard.Gap(4f);
+        listingStandard.CheckboxLabeled(
+            "RimTalk.Settings.IgnorePendingHotkeyEnabled".Translate().ToString(),
+            ref settings.IgnorePendingHotkeyEnabled
+        );
+        listingStandard.Gap(4f);
+        listingStandard.CheckboxLabeled(
+            "RimTalk.Settings.ProcessUserTalkRequestImmediately".Translate().ToString(),
+            ref settings.ProcessUserTalkRequestImmediately,
+            "RimTalk.Settings.ProcessUserTalkRequestImmediatelyTooltip".Translate().ToString()
+        );
+        listingStandard.Gap(4f);
+        listingStandard.CheckboxLabeled(
+            "RimTalk.Settings.DisplayUserTalkRequestImmediately".Translate().ToString(),
+            ref settings.DisplayUserTalkRequestImmediately,
+            "RimTalk.Settings.DisplayUserTalkRequestImmediatelyTooltip".Translate().ToString()
+        );
+
+        if (listingStandard.ButtonText("RimTalk.Settings.IgnoreAllPendingNow".Translate().ToString()))
+        {
+            int ignored = TalkService.IgnoreAllPendingTalks();
+            Messages.Message("RimTalk.Settings.IgnorePendingResult".Translate(ignored), MessageTypeDefOf.CautionInput, false);
+        }
 
         listingStandard.Gap(6f);
 
@@ -229,6 +307,19 @@ public partial class Settings
         if (listingStandard.ButtonText("RimTalk.Settings.ResetToDefault".Translate().ToString()))
         {
             settings.TalkInterval = 7;
+            settings.AutoTalkRequestInterval = 7;
+            settings.MaxTalkRequestQueueSize = 20;
+            settings.DisplayTalkInterval = 0.5f;
+            settings.IgnoreWaitSeconds = 6;
+            settings.ForceSpeakIgnored = false;
+            settings.IgnorePendingHotkeyEnabled = true;
+            settings.IgnorePendingHotkey = KeyCode.Home;
+            settings.ProcessUserTalkRequestImmediately = false;
+            settings.DisplayUserTalkRequestImmediately = true;
+            settings.SpeakWhilePaused = false;
+            settings.StopSpeakingInMenus = false;
+            settings.AdvancedMenuAvoidance = false;
+            settings.AlignTimingToNormalSpeed = false;
             settings.ProcessNonRimTalkInteractions = true;
             settings.AllowSimultaneousConversations = false;
             settings.DisplayTalkWhenDrafted = true;

--- a/Source/Settings/Settings_Basic.cs
+++ b/Source/Settings/Settings_Basic.cs
@@ -123,6 +123,22 @@ public partial class Settings
             "RimTalk.Settings.IgnorePendingHotkeyEnabled".Translate().ToString(),
             ref settings.IgnorePendingHotkeyEnabled
         );
+        if (settings.IgnorePendingHotkeyEnabled)
+        {
+            Rect hotkeyRect = listingStandard.GetRect(Text.LineHeight);
+            Widgets.Label(hotkeyRect.LeftPart(0.6f), "RimTalk.Settings.IgnorePendingHotkey".Translate().ToString());
+            if (Widgets.ButtonText(hotkeyRect.RightPart(0.4f), settings.IgnorePendingHotkey.ToString()))
+            {
+                var options = new List<FloatMenuOption>();
+                KeyCode[] hotkeys = { KeyCode.Delete, KeyCode.End, KeyCode.Backspace, KeyCode.Home };
+                foreach (KeyCode key in hotkeys)
+                {
+                    KeyCode captured = key;
+                    options.Add(new FloatMenuOption(captured.ToString(), () => settings.IgnorePendingHotkey = captured));
+                }
+                Find.WindowStack.Add(new FloatMenu(options));
+            }
+        }
         listingStandard.Gap(4f);
         listingStandard.CheckboxLabeled(
             "RimTalk.Settings.ProcessUserTalkRequestImmediately".Translate().ToString(),
@@ -138,8 +154,8 @@ public partial class Settings
 
         if (listingStandard.ButtonText("RimTalk.Settings.IgnoreAllPendingNow".Translate().ToString()))
         {
-            int ignored = TalkService.IgnoreAllPendingTalks();
-            Messages.Message("RimTalk.Settings.IgnorePendingResult".Translate(ignored), MessageTypeDefOf.CautionInput, false);
+            int cleared = TalkService.ClearAllPendingTalksForce();
+            Messages.Message("RimTalk.Settings.SkipPendingResult".Translate(cleared), MessageTypeDefOf.CautionInput, false);
         }
 
         listingStandard.Gap(6f);

--- a/Source/Util/CommonUtil.cs
+++ b/Source/Util/CommonUtil.cs
@@ -8,13 +8,14 @@ namespace RimTalk.Util;
 
 public static class CommonUtil
 {
-    public static bool HasPassed(int pastTick, double seconds)
+    public static bool HasPassed(int pastTick, double seconds, bool alignToNormalSpeed = false)
     {
-        return GenTicks.TicksGame - pastTick >= GetTicksForDuration(seconds);
+        return GenTicks.TicksGame - pastTick >= GetTicksForDuration(seconds, alignToNormalSpeed);
     }
-    public static int GetTicksForDuration(double seconds)
+
+    public static int GetTicksForDuration(double seconds, bool alignToNormalSpeed = false)
     {
-        var tickRate = GetCurrentTickRate();
+        var tickRate = alignToNormalSpeed ? 60 : GetCurrentTickRate();
         return (int)(seconds * tickRate);
     }
 


### PR DESCRIPTION
# Content

> This PR is a response to #80 .
> This PR is partly contributed by [@OCEAN](https://steamcommunity.com/profiles/76561198953899830) . The contribution should be marked 'from OCEAN'.

## What changed

This PR migrates and consolidates TalkRequest scheduling/display controls into the main mod, aligns runtime behavior with expected queue semantics, and fixes state consistency between runtime clearing and debug/API log visibility.

### 1) New queue/scheduling settings and plumbing
- Added configurable controls for:
  - TalkRequest auto-create interval
  - LLM processing interval
  - TalkRequest max queue size
  - display interval
  - ignore wait timing
  - force-display ignored talks
  - ignore-all-pending behavior
  - pause/menu-related speaking controls
  - optional 1x timing alignment behavior
  - user-request immediate processing / immediate display options
- Wired these settings through core data flow and tick processing.
- Updated settings UI and persisted settings model.

### 2) TalkRequest management fixes
- Refined queue handling and display/ignore decision logic to reduce unstable pacing and mismatches between generation cadence and visible output cadence.
- Improved hotkey/manual clear behavior so runtime actions map to intended queue-state transitions.
- Aligned several naming/text semantics in settings for better user-facing clarity.

### 3) Pending vs ignored state consistency fix
- Fixed an issue where ignored/cleared talks could still appear as `Pending` in debug views.

## Localization
- Updated keyed translations across all maintained languages for the new/adjusted settings and wording consistency.

## Validation
- Tested in real game environment.
- Should do more test before release.

PTAL.