### PR TITLE
fix: restore real ctx.history/chat.history output and stabilize history injection

### DIFF
--- a/Source/Data/TalkHistory.cs
+++ b/Source/Data/TalkHistory.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using RimTalk.Source.Data;
 using RimTalk.Util;
 using Verse;
 using Logger = RimTalk.Util.Logger;
@@ -11,6 +12,7 @@ namespace RimTalk.Data;
 public static class TalkHistory
 {
     private static readonly ConcurrentDictionary<int, List<(Role role, string message)>> MessageHistory = new();
+    private static readonly ConcurrentDictionary<int, List<(Role role, string message)>> DialogueHistory = new();
     private static readonly ConcurrentDictionary<Guid, int> SpokenTickCache = new() { [Guid.Empty] = 0 };
     private static readonly ConcurrentBag<Guid> IgnoredCache = [];
     
@@ -37,7 +39,16 @@ public static class TalkHistory
 
     public static void AddMessageHistory(Pawn pawn, string request, string response)
     {
-        AddMessageHistory(pawn, [(Role.User, request), (Role.AI, response)]);
+        if (pawn == null) return;
+
+        var messages = MessageHistory.GetOrAdd(pawn.thingIDNumber, _ => []);
+
+        lock (messages)
+        {
+            messages.Add((Role.User, request ?? ""));
+            messages.Add((Role.AI, response ?? ""));
+            EnsureRawMessageLimit(messages);
+        }
     }
 
     public static void AddConversationHistory(TalkRequest request, List<TalkResponse> responses)
@@ -45,6 +56,8 @@ public static class TalkHistory
         if (responses == null || responses.Count == 0) return;
 
         var historyPawns = new List<Pawn>();
+        string prompt = request?.Prompt ?? "";
+        string serializedResponses = JsonUtil.SerializeToJson(responses);
 
         void AddPawn(Pawn pawn)
         {
@@ -63,8 +76,29 @@ public static class TalkHistory
 
         foreach (var pawn in historyPawns)
         {
+            AddMessageHistory(pawn, prompt, serializedResponses);
+
             var conversationSlice = BuildConversationSliceForPawn(pawn, request, responses);
-            AddMessageHistory(pawn, conversationSlice);
+            AddDialogueHistory(pawn, conversationSlice);
+        }
+
+        Logger.Debug(
+            $"History saved for {historyPawns.Count} pawns; " +
+            $"initiator={request?.Initiator?.LabelShort ?? "null"}, " +
+            $"recipient={request?.Recipient?.LabelShort ?? "null"}, " +
+            $"responses={responses.Count}");
+    }
+
+    public static List<(Role role, string message)> GetDialogueHistory(Pawn pawn)
+    {
+        if (pawn == null || !DialogueHistory.TryGetValue(pawn.thingIDNumber, out var history))
+            return [];
+
+        lock (history)
+        {
+            return history
+                .Where(msg => !string.IsNullOrWhiteSpace(msg.message))
+                .ToList();
         }
     }
 
@@ -94,7 +128,24 @@ public static class TalkHistory
         }
     }
 
-    private static void EnsureMessageLimit(List<(Role role, string message)> messages)
+    private static void EnsureRawMessageLimit(List<(Role role, string message)> messages)
+    {
+        for (int i = messages.Count - 1; i > 0; i--)
+        {
+            if (messages[i].role == messages[i - 1].role)
+            {
+                messages.RemoveAt(i - 1);
+            }
+        }
+
+        int maxMessages = Settings.Get().Context.ConversationHistoryCount;
+        while (messages.Count > maxMessages * 2)
+        {
+            messages.RemoveAt(0);
+        }
+    }
+
+    private static void EnsureDialogueMessageLimit(List<(Role role, string message)> messages)
     {
         // First, ensure alternating pattern by merging consecutive entries with the same role
         for (int i = messages.Count - 1; i > 0; i--)
@@ -158,19 +209,19 @@ public static class TalkHistory
         return string.Join("\n", lines);
     }
 
-    private static void AddMessageHistory(Pawn pawn, IEnumerable<(Role role, string message)> messagesToAdd)
+    private static void AddDialogueHistory(Pawn pawn, IEnumerable<(Role role, string message)> messagesToAdd)
     {
         if (pawn == null || messagesToAdd == null) return;
 
         var normalizedMessages = NormalizeMessages(messagesToAdd).ToList();
         if (normalizedMessages.Count == 0) return;
 
-        var messages = MessageHistory.GetOrAdd(pawn.thingIDNumber, _ => []);
+        var messages = DialogueHistory.GetOrAdd(pawn.thingIDNumber, _ => []);
 
         lock (messages)
         {
             messages.AddRange(normalizedMessages);
-            EnsureMessageLimit(messages);
+            EnsureDialogueMessageLimit(messages);
         }
     }
 
@@ -184,6 +235,10 @@ public static class TalkHistory
 
         var likelyPartners = GetLikelyPartnerNames(pawn, request, responses);
         var strictSlice = new List<(Role role, string message)>();
+
+        var userInputMessage = BuildUserInputHistoryMessage(pawn, request);
+        if (!string.IsNullOrWhiteSpace(userInputMessage))
+            strictSlice.Add((Role.AI, userInputMessage));
 
         foreach (var response in responses)
         {
@@ -223,6 +278,21 @@ public static class TalkHistory
             foreach (var message in fallbackSlice)
                 yield return message;
         }
+    }
+
+    private static string BuildUserInputHistoryMessage(Pawn pawn, TalkRequest request)
+    {
+        if (pawn == null || request == null || !request.TalkType.IsFromUser())
+            return "";
+
+        var text = CleanHistoryText(request.RawPrompt);
+        if (string.IsNullOrWhiteSpace(text))
+            return "";
+
+        var speakerName = request.Recipient?.LabelShort ??
+                          request.Recipient?.Name?.ToStringShort ??
+                          "Player";
+        return $"{speakerName}: {text}";
     }
 
     private static IEnumerable<(Role role, string message)> BuildLooseConversationSliceForPawn(
@@ -342,6 +412,7 @@ public static class TalkHistory
     public static void Clear()
     {
         MessageHistory.Clear();
+        DialogueHistory.Clear();
         // clearing spokenCache may block child talks waiting to display
     }
 }

--- a/Source/Data/TalkHistory.cs
+++ b/Source/Data/TalkHistory.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using RimTalk.Util;
 using Verse;
+using Logger = RimTalk.Util.Logger;
 
 namespace RimTalk.Data;
 
@@ -182,6 +183,7 @@ public static class TalkHistory
             yield break;
 
         var likelyPartners = GetLikelyPartnerNames(pawn, request, responses);
+        var strictSlice = new List<(Role role, string message)>();
 
         foreach (var response in responses)
         {
@@ -196,6 +198,42 @@ public static class TalkHistory
             if (!spokenByPawn && !addressedToPawn && !fromLikelyPartner)
                 continue;
 
+            string content = FormatConversationMessageForPawn(pawn, response, spokenByPawn);
+            if (string.IsNullOrWhiteSpace(content))
+                continue;
+
+            strictSlice.Add((spokenByPawn ? Role.User : Role.AI, content));
+        }
+
+        if (strictSlice.Count > 0)
+        {
+            foreach (var message in strictSlice)
+                yield return message;
+            yield break;
+        }
+
+        var fallbackSlice = BuildLooseConversationSliceForPawn(pawn, responses).ToList();
+        if (fallbackSlice.Count > 0)
+        {
+            Logger.Debug(
+                $"History strict match empty for {pawn.LabelShort}; " +
+                $"falling back to loose slice. Responses={responses.Count}, " +
+                $"speakers=[{string.Join(", ", responses.Select(r => r?.Name).Where(n => !string.IsNullOrWhiteSpace(n)).Distinct())}]");
+
+            foreach (var message in fallbackSlice)
+                yield return message;
+        }
+    }
+
+    private static IEnumerable<(Role role, string message)> BuildLooseConversationSliceForPawn(
+        Pawn pawn,
+        List<TalkResponse> responses)
+    {
+        foreach (var response in responses)
+        {
+            if (response == null) continue;
+
+            bool spokenByPawn = MatchesPawnName(response.Name, pawn);
             string content = FormatConversationMessageForPawn(pawn, response, spokenByPawn);
             if (string.IsNullOrWhiteSpace(content))
                 continue;

--- a/Source/Data/TalkHistory.cs
+++ b/Source/Data/TalkHistory.cs
@@ -36,13 +36,34 @@ public static class TalkHistory
 
     public static void AddMessageHistory(Pawn pawn, string request, string response)
     {
-        var messages = MessageHistory.GetOrAdd(pawn.thingIDNumber, _ => []);
+        AddMessageHistory(pawn, [(Role.User, request), (Role.AI, response)]);
+    }
 
-        lock (messages)
+    public static void AddConversationHistory(TalkRequest request, List<TalkResponse> responses)
+    {
+        if (responses == null || responses.Count == 0) return;
+
+        var historyPawns = new List<Pawn>();
+
+        void AddPawn(Pawn pawn)
         {
-            messages.Add((Role.User, request));
-            messages.Add((Role.AI, response));
-            EnsureMessageLimit(messages);
+            if (pawn != null && !historyPawns.Contains(pawn))
+                historyPawns.Add(pawn);
+        }
+
+        AddPawn(request?.Initiator);
+        AddPawn(request?.Recipient);
+
+        foreach (var response in responses)
+        {
+            AddPawn(Cache.GetByName(response?.Name)?.Pawn);
+            AddPawn(Cache.GetByName(response?.TargetName)?.Pawn);
+        }
+
+        foreach (var pawn in historyPawns)
+        {
+            var conversationSlice = BuildConversationSliceForPawn(pawn, request, responses);
+            AddMessageHistory(pawn, conversationSlice);
         }
     }
 
@@ -74,12 +95,12 @@ public static class TalkHistory
 
     private static void EnsureMessageLimit(List<(Role role, string message)> messages)
     {
-        // First, ensure alternating pattern by removing consecutive duplicates from the end
+        // First, ensure alternating pattern by merging consecutive entries with the same role
         for (int i = messages.Count - 1; i > 0; i--)
         {
             if (messages[i].role == messages[i - 1].role)
             {
-                // Remove the earlier message of the consecutive pair
+                messages[i] = (messages[i].role, $"{messages[i - 1].message}\n{messages[i].message}");
                 messages.RemoveAt(i - 1);
             }
         }
@@ -134,6 +155,150 @@ public static class TalkHistory
         }
 
         return string.Join("\n", lines);
+    }
+
+    private static void AddMessageHistory(Pawn pawn, IEnumerable<(Role role, string message)> messagesToAdd)
+    {
+        if (pawn == null || messagesToAdd == null) return;
+
+        var normalizedMessages = NormalizeMessages(messagesToAdd).ToList();
+        if (normalizedMessages.Count == 0) return;
+
+        var messages = MessageHistory.GetOrAdd(pawn.thingIDNumber, _ => []);
+
+        lock (messages)
+        {
+            messages.AddRange(normalizedMessages);
+            EnsureMessageLimit(messages);
+        }
+    }
+
+    private static IEnumerable<(Role role, string message)> BuildConversationSliceForPawn(
+        Pawn pawn,
+        TalkRequest request,
+        List<TalkResponse> responses)
+    {
+        if (pawn == null || responses == null || responses.Count == 0)
+            yield break;
+
+        var likelyPartners = GetLikelyPartnerNames(pawn, request, responses);
+
+        foreach (var response in responses)
+        {
+            if (response == null) continue;
+
+            bool spokenByPawn = MatchesPawnName(response.Name, pawn);
+            bool addressedToPawn = MatchesPawnName(response.TargetName, pawn);
+            bool fromLikelyPartner = !spokenByPawn &&
+                                     !string.IsNullOrWhiteSpace(response.Name) &&
+                                     likelyPartners.Contains(response.Name);
+
+            if (!spokenByPawn && !addressedToPawn && !fromLikelyPartner)
+                continue;
+
+            string content = FormatConversationMessageForPawn(pawn, response, spokenByPawn);
+            if (string.IsNullOrWhiteSpace(content))
+                continue;
+
+            yield return (spokenByPawn ? Role.User : Role.AI, content);
+        }
+    }
+
+    private static IEnumerable<(Role role, string message)> NormalizeMessages(IEnumerable<(Role role, string message)> messages)
+    {
+        Role? lastRole = null;
+        string lastMessage = null;
+
+        foreach (var (role, message) in messages)
+        {
+            string cleaned = CleanHistoryText(message);
+            if (string.IsNullOrWhiteSpace(cleaned))
+                continue;
+
+            if (lastRole == role)
+            {
+                lastMessage += "\n" + cleaned;
+                continue;
+            }
+
+            if (lastRole.HasValue && !string.IsNullOrWhiteSpace(lastMessage))
+                yield return (lastRole.Value, lastMessage);
+
+            lastRole = role;
+            lastMessage = cleaned;
+        }
+
+        if (lastRole.HasValue && !string.IsNullOrWhiteSpace(lastMessage))
+            yield return (lastRole.Value, lastMessage);
+    }
+
+    private static HashSet<string> GetLikelyPartnerNames(Pawn pawn, TalkRequest request, List<TalkResponse> responses)
+    {
+        var partners = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        void AddPartner(Pawn otherPawn)
+        {
+            if (otherPawn != null && otherPawn != pawn)
+                partners.Add(otherPawn.LabelShort);
+        }
+
+        if (pawn == request?.Initiator)
+            AddPartner(request.Recipient);
+
+        if (pawn == request?.Recipient)
+            AddPartner(request.Initiator);
+
+        foreach (var response in responses)
+        {
+            if (response == null) continue;
+
+            if (MatchesPawnName(response.TargetName, pawn) && !string.IsNullOrWhiteSpace(response.Name))
+                partners.Add(response.Name);
+
+            if (MatchesPawnName(response.Name, pawn) && !string.IsNullOrWhiteSpace(response.TargetName))
+                partners.Add(response.TargetName);
+        }
+
+        if (partners.Count == 0)
+        {
+            var otherSpeakers = responses
+                .Select(r => r?.Name)
+                .Where(name => !string.IsNullOrWhiteSpace(name) && !MatchesPawnName(name, pawn))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            if (otherSpeakers.Count == 1)
+                partners.Add(otherSpeakers[0]);
+        }
+
+        return partners;
+    }
+
+    private static string FormatConversationMessageForPawn(Pawn pawn, TalkResponse response, bool spokenByPawn)
+    {
+        string text = CleanHistoryText(response.Text);
+        if (string.IsNullOrWhiteSpace(text))
+            return "";
+
+        if (spokenByPawn)
+        {
+            if (!string.IsNullOrWhiteSpace(response.TargetName) && !MatchesPawnName(response.TargetName, pawn))
+                return $"To {response.TargetName}: {text}";
+
+            return text;
+        }
+
+        return string.IsNullOrWhiteSpace(response.Name) ? text : $"{response.Name}: {text}";
+    }
+
+    private static bool MatchesPawnName(string name, Pawn pawn)
+    {
+        if (pawn == null || string.IsNullOrWhiteSpace(name))
+            return false;
+
+        return string.Equals(name, pawn.LabelShort, StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(name, pawn.Name?.ToStringShort, StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(name, pawn.Name?.ToStringFull, StringComparison.OrdinalIgnoreCase);
     }
 
     public static void Clear()

--- a/Source/Prompt/Parser/PromptContext.cs
+++ b/Source/Prompt/Parser/PromptContext.cs
@@ -41,10 +41,12 @@ public class PromptContext
     /// <summary>Chat history (Role, Message) - for inserting history in entries</summary>
     public List<(Role role, string message)> ChatHistory { get; set; } = new();
 
+    /// <summary>Simplified dialogue-only history derived from actual spoken lines.</summary>
+    public List<(Role role, string message)> DialogueHistory { get; set; } = new();
+
     public List<(Role role, string message)> GetChatHistory(bool simplified)
     {
-        if (CurrentPawn == null) return [];
-        return TalkHistory.GetMessageHistory(CurrentPawn, simplified);
+        return simplified ? DialogueHistory ?? [] : ChatHistory ?? [];
     }
 
     // Convenience properties - obtained from TalkRequest
@@ -104,6 +106,9 @@ public class PromptContext
             // to avoid pollution from DecoratePrompt which fills request.Prompt with full context
             ChatHistory = request?.Initiator != null
                 ? TalkHistory.GetMessageHistory(request.Initiator)
+                : [],
+            DialogueHistory = request?.Initiator != null
+                ? TalkHistory.GetDialogueHistory(request.Initiator)
                 : []
         };
     }

--- a/Source/Prompt/Parser/ScribanParser.cs
+++ b/Source/Prompt/Parser/ScribanParser.cs
@@ -111,7 +111,7 @@ public static class ScribanParser
 
             var chat = new ScriptObject();
             chat.Add("history", GetChatHistoryText(context));
-            chat.Add("history_simplified", GetChatHistoryText(context, simplified: true));
+            chat.Add("history_simplified", GetChatHistorySimplifiedText(context));
             scriptObject.Add("chat", chat);
             
             // 4. SHORTHANDS
@@ -365,32 +365,98 @@ public static class ScribanParser
             "is_monologue" or "ismonologue" => context.IsMonologue,
             "talk_type" or "talktype" => context.TalkType,
             "history" or "chat_history" or "chathistory" => GetContextHistoryText(context),
-            "history_simplified" or "chat_history_simplified" or "chathistorysimplified" => GetChatHistoryText(context, simplified: true),
+            "history_simplified" or "chat_history_simplified" or "chathistorysimplified" => GetChatHistorySimplifiedText(context),
             "pawn_count" or "pawncount" => context.AllPawns?.Count ?? 0,
             "map_id" or "mapid" => context.Map?.uniqueID ?? 0,
             _ => null
         };
     }
 
-    private static string GetChatHistoryText(PromptContext context, bool simplified = false)
+    private static string GetChatHistoryText(PromptContext context)
     {
-        var history = simplified ? context.GetChatHistory(simplified: true) : context.ChatHistory;
+        var blocks = GetDialogueHistoryBlocks(context);
 
-        if (history != null && history.Count > 0)
+        if (blocks.Count > 0)
         {
-            var lines = history.Select(h =>
-            {
-                var role = h.role == Role.User ? "User" : "Assistant";
-                var text = (h.message ?? "").Replace("\r\n", " ").Replace("\n", " ").Replace("\r", " ").Trim();
-                return $"{role}: {text}";
-            });
-            return string.Join("\n", lines);
+            var numberedBlocks = blocks.Select((block, i) => $"- {i + 1} | message=\n{block}");
+            return "Past dialogue record (reference only; avoid repeating verbatim):\n" + string.Join("\n\n", numberedBlocks);
         }
 
         if (context.IsPreview)
-            return "User: Hello!\nAssistant: Greetings from RimTalk. This is a placeholder for chat history.";
+            return "Past dialogue record (reference only; avoid repeating verbatim):\n" +
+                   "- 1 | message=\nPawnA: Hello!\n\n" +
+                   "- 2 | message=\nPawnB: Greetings from RimTalk. This is a placeholder for chat history.";
 
         return "";
+    }
+
+    private static string GetChatHistorySimplifiedText(PromptContext context)
+    {
+        var blocks = GetDialogueHistoryBlocks(context);
+        if (blocks.Count > 0)
+        {
+            var labeledBlocks = blocks.Select((block, i) => $"[message {i + 1}]\n{block}");
+            return "[Talk History]\n" + string.Join("\n\n", labeledBlocks);
+        }
+
+        if (context.IsPreview)
+            return "[Talk History]\n[message 1]\n  [1] PawnA: Hello!\n\n[message 2]\n  [1] PawnB: Greetings from RimTalk. This is a placeholder for chat history.";
+
+        return "";
+    }
+
+    private static List<string> GetDialogueHistoryBlocks(PromptContext context)
+    {
+        var history = context.GetChatHistory(simplified: true);
+        if (history == null || history.Count == 0)
+            return [];
+
+        var blocks = new List<string>();
+        foreach (var entry in history)
+        {
+            var formatted = FormatDialogueHistoryBlock(context, entry);
+            if (string.IsNullOrWhiteSpace(formatted))
+                continue;
+
+            blocks.Add(formatted.Trim());
+        }
+
+        int maxMessages = Math.Max(0, Settings.Get().Context.ConversationHistoryCount);
+        if (maxMessages == 0 || blocks.Count <= maxMessages)
+            return blocks;
+
+        return blocks.Skip(blocks.Count - maxMessages).ToList();
+    }
+
+    private static string FormatDialogueHistoryBlock(PromptContext context, (Role role, string message) historyEntry)
+    {
+        var turns = (historyEntry.message ?? "")
+            .Replace("\r\n", "\n")
+            .Replace("\r", "\n")
+            .Split('\n')
+            .Select(line => FormatDialogueHistoryTurn(context, historyEntry.role, line))
+            .Where(line => !string.IsNullOrWhiteSpace(line))
+            .ToList();
+
+        if (turns.Count == 0)
+            return "";
+
+        return string.Join("\n", turns.Select((turn, i) => $"  [{i + 1}] {turn}"));
+    }
+
+    private static string FormatDialogueHistoryTurn(PromptContext context, Role role, string rawTurn)
+    {
+        var text = (rawTurn ?? "").Trim();
+        if (string.IsNullOrWhiteSpace(text))
+            return "";
+
+        if (role == Role.User)
+        {
+            var speaker = context?.CurrentPawn?.LabelShort ?? "User";
+            return text.Contains(":") ? text : $"{speaker}: {text}";
+        }
+
+        return text.Contains(":") ? text : $"Other: {text}";
     }
 
     private static string GetContextHistoryText(PromptContext context)

--- a/Source/Prompt/Parser/ScribanParser.cs
+++ b/Source/Prompt/Parser/ScribanParser.cs
@@ -110,8 +110,8 @@ public static class ScribanParser
             scriptObject.Add("json", json);
 
             var chat = new ScriptObject();
-            string historyText = GetChatHistoryText(context);
-            chat.Add("history", historyText);
+            chat.Add("history", GetChatHistoryText(context));
+            chat.Add("history_simplified", GetChatHistoryText(context, simplified: true));
             scriptObject.Add("chat", chat);
             
             // 4. SHORTHANDS
@@ -364,21 +364,45 @@ public static class ScribanParser
             "user_prompt" or "userprompt" => context.UserPrompt ?? "",
             "is_monologue" or "ismonologue" => context.IsMonologue,
             "talk_type" or "talktype" => context.TalkType,
-            "history" or "chat_history" or "chathistory" => GetChatHistoryText(context),
+            "history" or "chat_history" or "chathistory" => GetContextHistoryText(context),
+            "history_simplified" or "chat_history_simplified" or "chathistorysimplified" => GetChatHistoryText(context, simplified: true),
             "pawn_count" or "pawncount" => context.AllPawns?.Count ?? 0,
             "map_id" or "mapid" => context.Map?.uniqueID ?? 0,
             _ => null
         };
     }
 
-    private static string GetChatHistoryText(PromptContext context)
+    private static string GetChatHistoryText(PromptContext context, bool simplified = false)
     {
-        if (context.ChatHistory != null && context.ChatHistory.Count > 0)
+        var history = simplified ? context.GetChatHistory(simplified: true) : context.ChatHistory;
+
+        if (history != null && history.Count > 0)
         {
-            var lines = context.ChatHistory.Select((h, i) =>
+            var lines = history.Select(h =>
             {
-                var text = (h.message ?? "").Replace("\r\n", " ").Replace("\n", " ").Replace("\r", " ");
-                return $"- {i + 1} | role={h.role} | text={text}";
+                var role = h.role == Role.User ? "User" : "Assistant";
+                var text = (h.message ?? "").Replace("\r\n", " ").Replace("\n", " ").Replace("\r", " ").Trim();
+                return $"{role}: {text}";
+            });
+            return string.Join("\n", lines);
+        }
+
+        if (context.IsPreview)
+            return "User: Hello!\nAssistant: Greetings from RimTalk. This is a placeholder for chat history.";
+
+        return "";
+    }
+
+    private static string GetContextHistoryText(PromptContext context)
+    {
+        var history = context.ChatHistory;
+        if (history != null && history.Count > 0)
+        {
+            var lines = history.Select((h, i) =>
+            {
+                var role = h.role == Role.User ? "User" : "Assistant";
+                var text = (h.message ?? "").Trim();
+                return $"- {i + 1} | role={role} | text={text}";
             });
             return "Conversation history (reference only; do not repeat or continue):\n" + string.Join("\n", lines);
         }
@@ -386,7 +410,7 @@ public static class ScribanParser
         if (context.IsPreview)
             return "Conversation history (reference only; do not repeat or continue):\n" +
                    "- 1 | role=User | text=Hello!\n" +
-                   "- 2 | role=AI | text=Greetings from RimTalk. This is a placeholder for chat history.";
+                   "- 2 | role=Assistant | text=Greetings from RimTalk. This is a placeholder for chat history.";
 
         return "";
     }

--- a/Source/Prompt/Parser/VariableDefinitions.cs
+++ b/Source/Prompt/Parser/VariableDefinitions.cs
@@ -102,8 +102,8 @@ public static class VariableDefinitions
         {
             ("lang", "Active native language name"),
             ("json.format", "JSON output instructions"),
-            ("chat.history", "Clean alternating dialogue history"),
-            ("chat.history_simplified", "History with AI JSON parsed and tags removed")
+            ("chat.history", "Dialogue-only history derived from spoken lines"),
+            ("chat.history_simplified", "Dialogue-only history merged into a single user-style block")
         };
 
         // 5. Mod-added variables from the API

--- a/Source/Prompt/Parser/VariableDefinitions.cs
+++ b/Source/Prompt/Parser/VariableDefinitions.cs
@@ -83,7 +83,7 @@ public static class VariableDefinitions
             ("ctx.IsMonologue", "True if this is a monologue"),
             ("ctx.prompt", "Alias of ctx.DialoguePrompt"),
             ("ctx.context", "Alias of ctx.PawnContext"),
-            ("ctx.history", "Alias of chat.history"),
+            ("ctx.history", "Detailed context history for prompt construction"),
             ("ctx.talk_type", "Alias of ctx.TalkType"),
             ("ctx.pawn_count", "Count of ctx.AllPawns"),
             ("ctx.map_id", "Map uniqueID")
@@ -102,7 +102,7 @@ public static class VariableDefinitions
         {
             ("lang", "Active native language name"),
             ("json.format", "JSON output instructions"),
-            ("chat.history", "Full alternating history (Raw)"),
+            ("chat.history", "Clean alternating dialogue history"),
             ("chat.history_simplified", "History with AI JSON parsed and tags removed")
         };
 

--- a/Source/Prompt/PromptManager.cs
+++ b/Source/Prompt/PromptManager.cs
@@ -266,10 +266,9 @@ public class PromptManager : IExposable
                 new()
                 {
                     Name = "Chat History",
-                    Role = PromptRole.User, // Visual placeholder
+                    Role = PromptRole.User,
                     Position = PromptPosition.Relative,
-                    IsMainChatHistory = true,
-                    Content = "{{chat.history}}"  // Special marker - history will be inserted here
+                    Content = "{{ctx.history}}"
                 },
                 // 3. Prompt Section
                 new()
@@ -306,21 +305,11 @@ public class PromptManager : IExposable
         Presets ??= new List<PromptPreset>();
         VariableStore ??= new VariableStore();
 
-        // Migration: Fix legacy chat history markers
+        // Cleanup legacy entries only
         if (Scribe.mode == LoadSaveMode.PostLoadInit || Scribe.mode == LoadSaveMode.LoadingVars)
         {
             foreach (var preset in Presets)
             {
-                // If no entry is marked as history, but we have one with the legacy content tag
-                if (!preset.Entries.Any(e => e.IsMainChatHistory))
-                {
-                    var legacyEntry = preset.Entries.FirstOrDefault(e => e.Content.Trim() == "{{chat.history}}");
-                    if (legacyEntry != null)
-                    {
-                        legacyEntry.IsMainChatHistory = true;
-                    }
-                }
-
                 preset.Entries.RemoveAll(e =>
                     string.Equals(e.Name, "Legacy Custom Instruction", StringComparison.OrdinalIgnoreCase));
             }
@@ -362,37 +351,60 @@ public class PromptManager : IExposable
         PromptPreset preset = GetActivePreset();
         if (preset == null) preset = CreateDefaultPreset();
 
-        string originalBaseContent = null;
-        PromptEntry baseEntry = null;
-
         if (!settings.UseAdvancedPromptMode)
         {
-            // Simple Mode: Use active preset but temporarily override Base Instruction
-            baseEntry = preset.Entries.FirstOrDefault(e =>
-                string.Equals(e.Name, "Base Instruction", StringComparison.OrdinalIgnoreCase));
-            
-            if (baseEntry != null)
-            {
-                originalBaseContent = baseEntry.Content;
-                baseEntry.Content = string.IsNullOrWhiteSpace(settings.SimpleModeInstruction) 
-                    ? Constant.DefaultInstruction 
-                    : settings.SimpleModeInstruction;
-            }
+            ScribanParser.ResetSessionVariables();
+            var simpleSegments = new List<PromptMessageSegment>();
+            var simpleMessages = BuildSimpleModeMessages(context, simpleSegments);
+            talkRequest.PromptMessageSegments = simpleSegments.Count > 0 ? simpleSegments : null;
+            return simpleMessages.Select(m => ((Role)m.role, m.content)).ToList();
         }
 
         // 4. Reset session variables and build
         ScribanParser.ResetSessionVariables();
         var segments = new List<PromptMessageSegment>();
         var messages = BuildMessagesFromPreset(preset, context, segments);
-        
-        if (baseEntry != null && originalBaseContent != null)
-        {
-            baseEntry.Content = originalBaseContent;
-        }
-        
+
         talkRequest.PromptMessageSegments = segments.Count > 0 ? segments : null;
         
         return messages.Select(m => ((Role)m.role, m.content)).ToList();
+    }
+
+    private List<(PromptRole role, string content)> BuildSimpleModeMessages(
+        PromptContext context,
+        List<PromptMessageSegment> segments)
+    {
+        var settings = Settings.Get();
+        var result = new List<(PromptRole role, string content)>();
+
+        void Add(PromptRole role, string content, string name)
+        {
+            if (string.IsNullOrWhiteSpace(content)) return;
+            result.Add((role, content));
+            segments?.Add(new PromptMessageSegment(name.ToLowerInvariant().Replace(" ", "-"), name, (Role)role, content));
+        }
+
+        Add(
+            PromptRole.System,
+            string.IsNullOrWhiteSpace(settings.SimpleModeInstruction) ? Constant.DefaultInstruction : settings.SimpleModeInstruction,
+            "Base Instruction");
+
+        Add(PromptRole.System, Constant.GetJsonInstruction(settings.ApplyMoodAndSocialEffects), "JSON Format");
+        Add(PromptRole.System, context.PawnContext, "Pawn Profiles");
+
+        if (context.ChatHistory != null)
+        {
+            foreach (var (role, message) in context.ChatHistory)
+            {
+                if (string.IsNullOrWhiteSpace(message)) continue;
+                result.Add(((PromptRole)role, message));
+                segments?.Add(new PromptMessageSegment("chat-history", "Chat History", role, message));
+            }
+        }
+
+        Add(PromptRole.User, context.DialoguePrompt, "Dialogue Prompt");
+
+        return MergeConsecutiveRoles(result);
     }
 
     private List<(PromptRole role, string content)> BuildMessagesFromPreset(
@@ -405,6 +417,20 @@ public class PromptManager : IExposable
         int systemBoundary = 0;
         bool boundarySet = false;
 
+        static bool IsPureContextHistoryMarker(string template)
+        {
+            if (string.IsNullOrWhiteSpace(template)) return false;
+            var normalized = Regex.Replace(template, @"\s+", "");
+            return normalized.Equals("{{ctx.history}}", StringComparison.OrdinalIgnoreCase);
+        }
+
+        static bool IsPureChatHistoryMarker(string template)
+        {
+            if (string.IsNullOrWhiteSpace(template)) return false;
+            var normalized = Regex.Replace(template, @"\s+", "");
+            return normalized.Equals("{{chat.history}}", StringComparison.OrdinalIgnoreCase);
+        }
+
         static PromptRole GetEffectiveRole(PromptEntry entry)
         {
             return string.IsNullOrWhiteSpace(entry.CustomRole) ? entry.Role : PromptRole.User;
@@ -416,42 +442,72 @@ public class PromptManager : IExposable
             return $"[role: {entry.CustomRole}]\n{content}";
         }
 
+        static List<(PromptRole role, string content)> BuildContextHistoryMessages(PromptContext context)
+        {
+            if (context?.ChatHistory != null && context.ChatHistory.Count > 0)
+            {
+                return context.ChatHistory
+                    .Select(h => ((PromptRole)h.role, h.message ?? ""))
+                    .ToList();
+            }
+
+            return
+            [
+                (PromptRole.User, ""),
+                (PromptRole.Assistant, "")
+            ];
+        }
+
         // 1. Process Relative entries in defined order (System/History/Prompt)
         foreach (var entry in preset.Entries.Where(e => e.Enabled && e.Position == PromptPosition.Relative))
         {
-            if (entry.IsMainChatHistory)
+            if (IsPureContextHistoryMarker(entry.Content))
             {
-                // Detect variant from content
-                var marker = entry.Content.Trim().ToLowerInvariant();
-                List<(Role role, string message)> history;
+                var expandedHistory = BuildContextHistoryMessages(context);
+                int firstInsertIndex = result.Count;
 
-                if (marker.Contains("history_simplified")) history = context.GetChatHistory(simplified: true);
-                else history = context.ChatHistory; 
-
-                if (history != null)
+                foreach (var (historyRole, historyContent) in expandedHistory)
                 {
-                    foreach (var (role, message) in history)
-                    {
-                        var pRole = (PromptRole)role;
-                        result.Add((pRole, message));
-                        segments?.Add(new PromptMessageSegment(entry.Id, entry.Name ?? "History", role, message));
-                    }
+                    result.Add((historyRole, historyContent));
+                    segments?.Add(new PromptMessageSegment(entry.Id, entry.Name ?? "Entry", (Role)historyRole, historyContent));
                 }
-                
-                if (!boundarySet) { systemBoundary = result.Count; boundarySet = true; }
-                lastHistoryIndex = result.Count;
+
+                if (!boundarySet && expandedHistory.Count > 0 && expandedHistory[0].role != PromptRole.System)
+                {
+                    systemBoundary = firstInsertIndex;
+                    boundarySet = true;
+                }
+
                 continue;
             }
 
             var content = ScribanParser.Render(entry.Content, context);
-            if (!string.IsNullOrWhiteSpace(content))
+            var role = GetEffectiveRole(entry);
+            var hasContent = !string.IsNullOrWhiteSpace(content);
+            var finalContent = hasContent ? ApplyCustomRolePrefix(entry, content) : "";
+
+            if (!hasContent && IsPureChatHistoryMarker(entry.Content))
             {
-                var role = GetEffectiveRole(entry);
-                var finalContent = ApplyCustomRolePrefix(entry, content);
-                
+                result.Add((PromptRole.User, ""));
+                result.Add((PromptRole.Assistant, ""));
+                segments?.Add(new PromptMessageSegment(entry.Id, entry.Name ?? "Entry", Role.User, ""));
+                segments?.Add(new PromptMessageSegment(entry.Id, entry.Name ?? "Entry", Role.AI, ""));
+
+                if (!boundarySet)
+                {
+                    systemBoundary = result.Count - 2;
+                    boundarySet = true;
+                }
+
+                continue;
+            }
+
+            segments?.Add(new PromptMessageSegment(entry.Id, entry.Name ?? "Entry", (Role)role, finalContent));
+
+            if (hasContent)
+            {
                 result.Add((role, finalContent));
-                segments?.Add(new PromptMessageSegment(entry.Id, entry.Name ?? "Entry", (Role)role, finalContent));
-                
+
                 // systemBoundary is the end of the initial continuous block of system messages
                 if (!boundarySet && role != PromptRole.System)
                 {
@@ -466,21 +522,55 @@ public class PromptManager : IExposable
         // 2. Process InChat entries (Anchored to History)
         foreach (var entry in preset.GetInChatEntries())
         {
-            var content = ScribanParser.Render(entry.Content, context);
-            if (!string.IsNullOrWhiteSpace(content))
+            if (IsPureContextHistoryMarker(entry.Content))
             {
-                var role = GetEffectiveRole(entry);
-                var finalContent = ApplyCustomRolePrefix(entry, content);
-                
+                var expandedHistory = BuildContextHistoryMessages(context);
+                var insertIndex = Math.Max(systemBoundary, lastHistoryIndex - entry.InChatDepth);
+
+                for (int i = 0; i < expandedHistory.Count; i++)
+                {
+                    var (historyRole, historyContent) = expandedHistory[i];
+                    result.Insert(insertIndex + i, (historyRole, historyContent));
+                    segments?.Add(new PromptMessageSegment(entry.Id, entry.Name ?? "Entry", (Role)historyRole, historyContent));
+                }
+
+                if (insertIndex <= lastHistoryIndex)
+                    lastHistoryIndex += expandedHistory.Count;
+
+                continue;
+            }
+
+            var content = ScribanParser.Render(entry.Content, context);
+            var role = GetEffectiveRole(entry);
+            var hasContent = !string.IsNullOrWhiteSpace(content);
+            var finalContent = hasContent ? ApplyCustomRolePrefix(entry, content) : "";
+
+            if (!hasContent && IsPureChatHistoryMarker(entry.Content))
+            {
+                var insertIndex = Math.Max(systemBoundary, lastHistoryIndex - entry.InChatDepth);
+                result.Insert(insertIndex, (PromptRole.User, ""));
+                result.Insert(insertIndex + 1, (PromptRole.Assistant, ""));
+                segments?.Add(new PromptMessageSegment(entry.Id, entry.Name ?? "Entry", Role.User, ""));
+                segments?.Add(new PromptMessageSegment(entry.Id, entry.Name ?? "Entry", Role.AI, ""));
+
+                if (insertIndex <= lastHistoryIndex)
+                    lastHistoryIndex += 2;
+
+                continue;
+            }
+
+            segments?.Add(new PromptMessageSegment(entry.Id, entry.Name ?? "Entry", (Role)role, finalContent));
+
+            if (hasContent)
+            {
                 // Calculate position relative to history end, clamped by system boundary
                 var insertIndex = Math.Max(systemBoundary, lastHistoryIndex - entry.InChatDepth);
-                
+
                 result.Insert(insertIndex, (role, finalContent));
-                segments?.Insert(insertIndex, new PromptMessageSegment(entry.Id, entry.Name ?? "Entry", (Role)role, finalContent));
-                
+
                 // Shift anchor and boundary forward since we increased the list size
                 if (insertIndex <= lastHistoryIndex) lastHistoryIndex++;
-                systemBoundary++; 
+                systemBoundary++;
             }
         }
 

--- a/Source/Service/TalkService.cs
+++ b/Source/Service/TalkService.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using RimTalk.Data;
 using RimTalk.Prompt;
@@ -19,6 +20,19 @@ namespace RimTalk.Service;
 /// </summary>
 public static class TalkService
 {
+    private static int _activeGenerationPipelineCount;
+
+    private static bool IsGenerationPipelineBusy()
+    {
+        return Volatile.Read(ref _activeGenerationPipelineCount) > 0;
+    }
+
+    private static void StartGenerationPipeline(TalkRequest talkRequest)
+    {
+        Interlocked.Increment(ref _activeGenerationPipelineCount);
+        Task.Run(() => GenerateAndProcessTalkAsync(talkRequest));
+    }
+
     /// <summary>
     /// Initiates the process of generating a conversation. It performs initial checks and then
     /// starts a background task to handle the actual AI communication.
@@ -29,7 +43,7 @@ public static class TalkService
         var settings = Settings.Get();
         if (!settings.IsEnabled || !CommonUtil.ShouldAiBeActiveOnSpeed()) return false;
         if (settings.GetActiveConfig() == null) return false;
-        if (AIService.IsBusy()) return false;
+        if (AIService.IsBusy() || IsGenerationPipelineBusy()) return false;
 
         PawnState pawn1 = Cache.Get(talkRequest.Initiator);
         if (!talkRequest.TalkType.IsFromUser() && (pawn1 == null || !pawn1.CanGenerateTalk())) return false;
@@ -86,8 +100,9 @@ public static class TalkService
             talkRequest.Prompt = extracted;
         }
         
-        // Offload the AI request and processing to a background thread to avoid blocking the game's main thread.
-        Task.Run(() => GenerateAndProcessTalkAsync(talkRequest));
+        // Offload the AI request and post-processing to a background thread.
+        // The pipeline busy flag remains set until history has been written back.
+        StartGenerationPipeline(talkRequest);
 
         pawn1.MarkRequestSpoken(talkRequest);
         
@@ -128,7 +143,7 @@ public static class TalkService
             );
 
             // Once the stream is complete, save the full conversation to history.
-            AddResponsesToHistory(receivedResponses, talkRequest.Prompt);
+            AddResponsesToHistory(talkRequest, receivedResponses);
         }
         catch (Exception ex)
         {
@@ -137,25 +152,18 @@ public static class TalkService
         finally
         {
             Cache.Get(initiator).IsGeneratingTalk = false;
+            Interlocked.Decrement(ref _activeGenerationPipelineCount);
         }
     }
 
     /// <summary>
-    /// Serializes the generated responses and adds them to the message history for all involved pawns.
+    /// Saves the generated conversation to per-pawn history using the actual spoken lines.
     /// </summary>
-    private static void AddResponsesToHistory(List<TalkResponse> responses, string prompt)
+    private static void AddResponsesToHistory(TalkRequest talkRequest, List<TalkResponse> responses)
     {
         if (!responses.Any()) return;
-        string serializedResponses = JsonUtil.SerializeToJson(responses);
-        var uniquePawns = responses
-            .Select(r => Cache.GetByName(r.Name)?.Pawn)
-            .Where(p => p != null)
-            .Distinct();
 
-        foreach (var pawn in uniquePawns)
-        {
-            TalkHistory.AddMessageHistory(pawn, prompt, serializedResponses);
-        }
+        TalkHistory.AddConversationHistory(talkRequest, responses);
     }
 
     /// <summary>
@@ -218,7 +226,7 @@ public static class TalkService
     /// </summary>
     public static void GenerateTalkDebug(TalkRequest talkRequest)
     {
-        Task.Run(() => GenerateAndProcessTalkAsync(talkRequest));
+        StartGenerationPipeline(talkRequest);
     }
 
     /// <summary>

--- a/Source/Settings/Settings_PromptPreset.cs
+++ b/Source/Settings/Settings_PromptPreset.cs
@@ -266,7 +266,7 @@ public partial class Settings
                 Rect erow = new Rect(0f, ey, eViewRect.width, 24f);
                 if (_selectedEntryId == entry.Id) Widgets.DrawHighlight(erow);
 
-                bool isHistoryMarker = entry.IsMainChatHistory;
+                bool isHistoryMarker = false;
 
                 bool en = entry.Enabled;
                 Widgets.Checkbox(new Vector2(4f, ey + 4f), ref en, 16f);
@@ -401,7 +401,7 @@ public partial class Settings
         }
 
         // -- Row 2 (Left Side): Entry Name --
-        bool isHistoryMarker = e.IsMainChatHistory;
+        bool isHistoryMarker = false;
 
         Widgets.Label(new Rect(labelX, y, inputX - 10, 24f), "RimTalk.Settings.PromptPreset.EntryName".Translate());
         if (isHistoryMarker)

--- a/Source/UI/DebugWindow.cs
+++ b/Source/UI/DebugWindow.cs
@@ -1539,7 +1539,7 @@ public class DebugWindow : Window
             sb.Append("RimTalk.DebugWindow.FormatRole".Translate());
             sb.Append(": ");
             sb.AppendLine(roleLabel);
-            sb.AppendLine(segment.Content ?? "");
+            sb.AppendLine(string.IsNullOrWhiteSpace(segment.Content) ? "(empty)" : segment.Content);
             
             // Add blank line between messages (except after the last one)
             if (i < segments.Count - 1)


### PR DESCRIPTION
## Summary  
This PR fixes how `{{ctx.history}}` and `{{chat.history}}` are built and rendered so they reflect real pawn conversation history instead of prompt residue or incomplete AI payloads. It also fixes intermittent empty-history gaps caused by a race between AI completion and history write-back.

## What Changed
- Reworked `TalkHistory` to store per-pawn conversation slices from actual `TalkResponse` lines instead of saving the full prompt and serialized full response blob.
- Added per-pawn history extraction logic so each pawn only keeps its own recent dialogue and relevant counterpart lines.
- Merged consecutive same-role history items and kept history trimming aligned with `ConversationHistoryCount`.
- Split history rendering semantics:
  - `{{ctx.history}}` now renders detailed `role/text` context history for prompt construction.
  - `{{chat.history}}` renders simplified dialogue history.
- Updated the default advanced preset to explicitly include `{{ctx.history}}`.
- Kept simple mode on its own dedicated history/message-building path.
- Preserved empty history sections for both debug display and actual LLM request output when players explicitly place `{{ctx.history}}` or `{{chat.history}}` in presets.
- Fixed a race in `TalkService` so a new request cannot start after streaming finishes but before history has been written back.

## Why
The PR reduce the rate that LLM repeat the former output.

PTAL.