### PR TITLE
fix: add a new variable {{chat.dialogue_history}}

### DIFF
--- a/Source/Data/TalkHistory.cs
+++ b/Source/Data/TalkHistory.cs
@@ -147,19 +147,8 @@ public static class TalkHistory
 
     private static void EnsureDialogueMessageLimit(List<(Role role, string message)> messages)
     {
-        // First, ensure alternating pattern by merging consecutive entries with the same role
-        for (int i = messages.Count - 1; i > 0; i--)
-        {
-            if (messages[i].role == messages[i - 1].role)
-            {
-                messages[i] = (messages[i].role, $"{messages[i - 1].message}\n{messages[i].message}");
-                messages.RemoveAt(i - 1);
-            }
-        }
-
-        // Then, enforce the maximum message limit by removing the oldest messages
         int maxMessages = Settings.Get().Context.ConversationHistoryCount;
-        while (messages.Count > maxMessages * 2)
+        while (messages.Count > maxMessages)
         {
             messages.RemoveAt(0);
         }
@@ -213,7 +202,7 @@ public static class TalkHistory
     {
         if (pawn == null || messagesToAdd == null) return;
 
-        var normalizedMessages = NormalizeMessages(messagesToAdd).ToList();
+        var normalizedMessages = NormalizeDialogueMessages(messagesToAdd).ToList();
         if (normalizedMessages.Count == 0) return;
 
         var messages = DialogueHistory.GetOrAdd(pawn.thingIDNumber, _ => []);
@@ -233,51 +222,25 @@ public static class TalkHistory
         if (pawn == null || responses == null || responses.Count == 0)
             yield break;
 
-        var likelyPartners = GetLikelyPartnerNames(pawn, request, responses);
-        var strictSlice = new List<(Role role, string message)>();
+        var lines = new List<string>();
 
         var userInputMessage = BuildUserInputHistoryMessage(pawn, request);
         if (!string.IsNullOrWhiteSpace(userInputMessage))
-            strictSlice.Add((Role.AI, userInputMessage));
+            lines.Add(userInputMessage);
 
         foreach (var response in responses)
         {
             if (response == null) continue;
 
-            bool spokenByPawn = MatchesPawnName(response.Name, pawn);
-            bool addressedToPawn = MatchesPawnName(response.TargetName, pawn);
-            bool fromLikelyPartner = !spokenByPawn &&
-                                     !string.IsNullOrWhiteSpace(response.Name) &&
-                                     likelyPartners.Contains(response.Name);
-
-            if (!spokenByPawn && !addressedToPawn && !fromLikelyPartner)
-                continue;
-
-            string content = FormatConversationMessageForPawn(pawn, response, spokenByPawn);
+            string content = FormatDialogueTranscriptLine(response);
             if (string.IsNullOrWhiteSpace(content))
                 continue;
 
-            strictSlice.Add((spokenByPawn ? Role.User : Role.AI, content));
+            lines.Add(content);
         }
 
-        if (strictSlice.Count > 0)
-        {
-            foreach (var message in strictSlice)
-                yield return message;
-            yield break;
-        }
-
-        var fallbackSlice = BuildLooseConversationSliceForPawn(pawn, responses).ToList();
-        if (fallbackSlice.Count > 0)
-        {
-            Logger.Debug(
-                $"History strict match empty for {pawn.LabelShort}; " +
-                $"falling back to loose slice. Responses={responses.Count}, " +
-                $"speakers=[{string.Join(", ", responses.Select(r => r?.Name).Where(n => !string.IsNullOrWhiteSpace(n)).Distinct())}]");
-
-            foreach (var message in fallbackSlice)
-                yield return message;
-        }
+        if (lines.Count > 0)
+            yield return (Role.User, string.Join("\n", lines));
     }
 
     private static string BuildUserInputHistoryMessage(Pawn pawn, TalkRequest request)
@@ -340,6 +303,32 @@ public static class TalkHistory
             yield return (lastRole.Value, lastMessage);
     }
 
+    private static IEnumerable<(Role role, string message)> NormalizeDialogueMessages(IEnumerable<(Role role, string message)> messages)
+    {
+        foreach (var (role, message) in messages)
+        {
+            string cleaned = CleanDialogueHistoryText(message);
+            if (!string.IsNullOrWhiteSpace(cleaned))
+                yield return (role, cleaned);
+        }
+    }
+
+    private static string CleanDialogueHistoryText(string text)
+    {
+        if (string.IsNullOrWhiteSpace(text)) return "";
+
+        var cleaned = CommonUtil.StripFormattingTags(text)
+            .Replace("\r\n", "\n")
+            .Replace("\r", "\n");
+
+        var lines = cleaned
+            .Split('\n')
+            .Select(line => line.Trim())
+            .Where(line => !string.IsNullOrWhiteSpace(line));
+
+        return string.Join("\n", lines).Trim();
+    }
+
     private static HashSet<string> GetLikelyPartnerNames(Pawn pawn, TalkRequest request, List<TalkResponse> responses)
     {
         var partners = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -397,6 +386,19 @@ public static class TalkHistory
         }
 
         return string.IsNullOrWhiteSpace(response.Name) ? text : $"{response.Name}: {text}";
+    }
+
+    private static string FormatDialogueTranscriptLine(TalkResponse response)
+    {
+        string text = CleanHistoryText(response?.Text);
+        if (string.IsNullOrWhiteSpace(text))
+            return "";
+
+        string speaker = response?.Name;
+        if (string.IsNullOrWhiteSpace(speaker))
+            speaker = "Unknown";
+
+        return $"{speaker}: {text}";
     }
 
     private static bool MatchesPawnName(string name, Pawn pawn)

--- a/Source/Prompt/Parser/PromptContext.cs
+++ b/Source/Prompt/Parser/PromptContext.cs
@@ -41,12 +41,20 @@ public class PromptContext
     /// <summary>Chat history (Role, Message) - for inserting history in entries</summary>
     public List<(Role role, string message)> ChatHistory { get; set; } = new();
 
+    /// <summary>Raw chat history converted to readable text, preserving the original user/assistant structure.</summary>
+    public List<(Role role, string message)> SimplifiedChatHistory { get; set; } = new();
+
     /// <summary>Simplified dialogue-only history derived from actual spoken lines.</summary>
     public List<(Role role, string message)> DialogueHistory { get; set; } = new();
 
     public List<(Role role, string message)> GetChatHistory(bool simplified)
     {
-        return simplified ? DialogueHistory ?? [] : ChatHistory ?? [];
+        return simplified ? SimplifiedChatHistory ?? [] : ChatHistory ?? [];
+    }
+
+    public List<(Role role, string message)> GetDialogueHistory()
+    {
+        return DialogueHistory ?? [];
     }
 
     // Convenience properties - obtained from TalkRequest
@@ -106,6 +114,9 @@ public class PromptContext
             // to avoid pollution from DecoratePrompt which fills request.Prompt with full context
             ChatHistory = request?.Initiator != null
                 ? TalkHistory.GetMessageHistory(request.Initiator)
+                : [],
+            SimplifiedChatHistory = request?.Initiator != null
+                ? TalkHistory.GetMessageHistory(request.Initiator, simplified: true)
                 : [],
             DialogueHistory = request?.Initiator != null
                 ? TalkHistory.GetDialogueHistory(request.Initiator)

--- a/Source/Prompt/Parser/ScribanParser.cs
+++ b/Source/Prompt/Parser/ScribanParser.cs
@@ -112,6 +112,7 @@ public static class ScribanParser
             var chat = new ScriptObject();
             chat.Add("history", GetChatHistoryText(context));
             chat.Add("history_simplified", GetChatHistorySimplifiedText(context));
+            chat.Add("dialogue_history", GetDialogueHistoryText(context));
             scriptObject.Add("chat", chat);
             
             // 4. SHORTHANDS
@@ -366,6 +367,7 @@ public static class ScribanParser
             "talk_type" or "talktype" => context.TalkType,
             "history" or "chat_history" or "chathistory" => GetContextHistoryText(context),
             "history_simplified" or "chat_history_simplified" or "chathistorysimplified" => GetChatHistorySimplifiedText(context),
+            "dialogue_history" or "dialoguehistory" or "talk_history" or "talkhistory" => GetDialogueHistoryText(context),
             "pawn_count" or "pawncount" => context.AllPawns?.Count ?? 0,
             "map_id" or "mapid" => context.Map?.uniqueID ?? 0,
             _ => null
@@ -373,6 +375,36 @@ public static class ScribanParser
     }
 
     private static string GetChatHistoryText(PromptContext context)
+    {
+        return FormatRoleHistory(
+            context.ChatHistory,
+            context.IsPreview ? "User: Hello!\nAssistant: Greetings from RimTalk. This is a placeholder for chat history." : "");
+    }
+
+    private static string GetChatHistorySimplifiedText(PromptContext context)
+    {
+        return FormatRoleHistory(
+            context.GetChatHistory(simplified: true),
+            context.IsPreview ? "User: Hello!\nAssistant: Greetings from RimTalk. This is a placeholder for chat history." : "");
+    }
+
+    private static string FormatRoleHistory(List<(Role role, string message)> history, string previewFallback)
+    {
+        if (history != null && history.Count > 0)
+        {
+            var lines = history.Select(h =>
+            {
+                var role = h.role == Role.User ? "User" : "Assistant";
+                var text = (h.message ?? "").Replace("\r\n", " ").Replace("\n", " ").Replace("\r", " ").Trim();
+                return $"{role}: {text}";
+            });
+            return string.Join("\n", lines);
+        }
+
+        return previewFallback ?? "";
+    }
+
+    private static string GetDialogueHistoryText(PromptContext context)
     {
         var blocks = GetDialogueHistoryBlocks(context);
 
@@ -390,24 +422,9 @@ public static class ScribanParser
         return "";
     }
 
-    private static string GetChatHistorySimplifiedText(PromptContext context)
-    {
-        var blocks = GetDialogueHistoryBlocks(context);
-        if (blocks.Count > 0)
-        {
-            var labeledBlocks = blocks.Select((block, i) => $"[message {i + 1}]\n{block}");
-            return "[Talk History]\n" + string.Join("\n\n", labeledBlocks);
-        }
-
-        if (context.IsPreview)
-            return "[Talk History]\n[message 1]\n  [1] PawnA: Hello!\n\n[message 2]\n  [1] PawnB: Greetings from RimTalk. This is a placeholder for chat history.";
-
-        return "";
-    }
-
     private static List<string> GetDialogueHistoryBlocks(PromptContext context)
     {
-        var history = context.GetChatHistory(simplified: true);
+        var history = context.GetDialogueHistory();
         if (history == null || history.Count == 0)
             return [];
 

--- a/Source/Prompt/Parser/VariableDefinitions.cs
+++ b/Source/Prompt/Parser/VariableDefinitions.cs
@@ -102,8 +102,9 @@ public static class VariableDefinitions
         {
             ("lang", "Active native language name"),
             ("json.format", "JSON output instructions"),
-            ("chat.history", "Dialogue-only history derived from spoken lines"),
-            ("chat.history_simplified", "Dialogue-only history merged into a single user-style block")
+            ("chat.history", "Original user/assistant chat history"),
+            ("chat.history_simplified", "Original user/assistant chat history with JSON responses converted to readable text"),
+            ("chat.dialogue_history", "Dialogue-only transcript history grouped by past conversation"),
         };
 
         // 5. Mod-added variables from the API


### PR DESCRIPTION
## Content

The PR is a additional change for #87 .

## What does the PR do?

- Revert `{{chat.history}}` to earlier version contains `user` and `assistant` info;
- Add a new  variable `{{chat.dialogue_history}}` for compressed dialogue;

PTAL.