### PR TITLE
fix: optimize tick rate calculation and ignore .vs folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ PublishedFileId.txt
 Folder.DotSettings.user
 Directory.Build.props
 *.sh
+.vs
 
 ## Interaction bubble library
 Libs/Bubbles.dll

--- a/Source/Util/CommonUtil.cs
+++ b/Source/Util/CommonUtil.cs
@@ -20,21 +20,8 @@ public static class CommonUtil
 
     private static int GetCurrentTickRate()
     {
-        switch (Find.TickManager.CurTimeSpeed)
-        {
-            case TimeSpeed.Paused:
-                return 0;
-            case TimeSpeed.Normal:
-                return 60;
-            case TimeSpeed.Fast:
-                return 180;
-            case TimeSpeed.Superfast:
-                return 360;
-            case TimeSpeed.Ultrafast:
-                return 1500;
-            default:
-                return 60; // Default to normal speed if unknown
-        }
+        TickManager tickManager = Find.TickManager;
+        return (int)(((tickManager != null) ? tickManager.TickRateMultiplier : 1f) * 60f);
     }
 
     // Struct containing all necessary in-game data


### PR DESCRIPTION
## Summary
- **Optimization:** Refactored `GetCurrentTickRate` in `CommonUtil.cs` to use `TickManager.TickRateMultiplier` instead of hardcoded `TimeSpeed` values. This provides a more accurate and dynamic tick rate calculation, ensuring the correct tick rate is returned even when using game-speed-altering mods like Smart Speed (700k+ subscribers).
- **Maintenance:** Added `.vs` to `.gitignore` to prevent Visual Studio configuration and temporary files from being tracked.