### PR TITLE
fix: prevent NullReferenceException when parsing pawn thoughts and improve rendering stability

### DIFF
--- a/Source/Service/ContextBuilder.cs
+++ b/Source/Service/ContextBuilder.cs
@@ -238,8 +238,8 @@ public static class ContextBuilder
 
         // For Short level, only include latest 3 thoughts
         var thoughts = infoLevel == PromptService.InfoLevel.Short
-            ? allThoughts.Keys.Take(3).Select(t => CommonUtil.Sanitize(t.LabelCap))
-            : allThoughts.Keys.Select(t => CommonUtil.Sanitize(t.LabelCap));
+            ? allThoughts.Keys.Take(3).Select(t => CommonUtil.Sanitize(t.LabelCap ?? t.def?.defName ?? "UnknownThought"))
+            : allThoughts.Keys.Select(t => CommonUtil.Sanitize(t.LabelCap ?? t.def?.defName ?? "UnknownThought"));
 
         if (thoughts.Any())
             return $"Memory: {string.Join(", ", thoughts)}";
@@ -256,9 +256,9 @@ public static class ContextBuilder
             return null;
 
         var thoughts = allThoughts
-            .OrderBy(kvp => kvp.Key.LabelCap.ToString())
+            .OrderBy(kvp => kvp.Key.LabelCap)
             .Select(kvp =>
-                $"{CommonUtil.Sanitize(kvp.Key.LabelCap)}({kvp.Value.ToStringWithSign()})");
+                $"{CommonUtil.Sanitize(kvp.Key.LabelCap ?? kvp.Key.def?.defName ?? "UnknownThought")}({kvp.Value.ToStringWithSign()})");
 
         return $"Thoughts: {string.Join(", ", thoughts)}";
     }


### PR DESCRIPTION
**Motivation & Context**
Under certain game conditions or due to interactions with specific mods, some of a pawn's thoughts may lack a localized label (`LabelCap`). Previously, the code did not handle these null values defensively when reading or sorting thoughts, leading to a `NullReferenceException`.

This is not an edge case; for example, when a character has an "Anesthesia" related thought—**which is a vanilla game feature and occurs quite frequently**—the `fullthrought` variable would directly trigger a crash, causing the entire Scriban entry rendering to fail. This severely impacts dialogue generation and other features relying on this context.

**What changed**
1. **Robust Fallback Mechanism:** In both `GetThoughtsContext` and `GetAllThoughtsContext`, if `LabelCap` is null, the code now gracefully falls back to using `t.def?.defName`. If that is also unavailable, it defaults to `"UnknownThought"`. This ensures that string formatting and sanitization (`CommonUtil.Sanitize`) always receive a valid string.
2. **Safe Sorting Logic:** In `GetAllThoughtsContext`, the unsafe `LabelCap.ToString()` call during sorting was removed. The sorting now directly uses `LabelCap` within LINQ's `.OrderBy` (which natively and safely handles null comparisons), preventing crashes caused by calling `.ToString()` on a null reference.

**How Has This Been Tested?**
- [x] Verified local builds using `dotnet build` with no related errors.
- [x] Confirmed that when encountering thoughts with undefined labels (such as the frequently occurring vanilla "Anesthesia" thought), the fallback mechanism triggers correctly and Scriban rendering no longer crashes.