### PR TITLE
fix: fix quotation mark parser

### DIFF
--- a/Source/Util/JsonStreamParser.cs
+++ b/Source/Util/JsonStreamParser.cs
@@ -32,17 +32,12 @@ public class JsonStreamParser<T> where T : class
 
             string jsonObj = text.Substring(objStart, objEnd - objStart + 1);
 
-            try
+            if (JsonUtil.TryDeserializeFromJson<T>(jsonObj, out var parsedObject, out _))
             {
-                var parsedObject = JsonUtil.DeserializeFromJson<T>(jsonObj);
                 if (parsedObject != null)
                 {
                     newObjects.Add(parsedObject);
                 }
-            }
-            catch
-            {
-                // Not a valid object, continue searching
             }
 
             searchStart = objEnd + 1;
@@ -62,6 +57,7 @@ public class JsonStreamParser<T> where T : class
         int depth = 0;
         bool inString = false;
         bool escaped = false;
+        char activeQuote = '\0';
 
         for (int i = openIndex; i < text.Length; i++)
         {
@@ -75,13 +71,29 @@ public class JsonStreamParser<T> where T : class
 
             if (c == '\\')
             {
-                escaped = true;
+                if (inString)
+                    escaped = true;
                 continue;
             }
 
-            if (c == '"')
+            if (JsonUtil.IsJsonQuote(c))
             {
-                inString = !inString;
+                if (!inString)
+                {
+                    inString = true;
+                    activeQuote = c;
+                    continue;
+                }
+
+                if (IsClosingQuoteForActiveString(activeQuote, c))
+                {
+                    if (JsonUtil.IsLikelyStringTerminator(text, i))
+                    {
+                        inString = false;
+                        activeQuote = '\0';
+                    }
+                }
+
                 continue;
             }
 
@@ -99,5 +111,19 @@ public class JsonStreamParser<T> where T : class
         }
 
         return -1; // No matching brace found
+    }
+
+    private static bool IsClosingQuoteForActiveString(char activeQuote, char current)
+    {
+        if (activeQuote == '"')
+            return current == '"';
+
+        if (activeQuote == '“')
+            return current == '”' || current == '“' || current == '"';
+
+        if (activeQuote == '”')
+            return current == '”' || current == '“' || current == '"';
+
+        return current == '"';
     }
 }

--- a/Source/Util/JsonUtil.cs
+++ b/Source/Util/JsonUtil.cs
@@ -107,6 +107,8 @@ public static class JsonUtil
             }
         }
 
+        sanitized = ProtectMalformedQuotes(sanitized);
+
         bool isEnumerable = typeof(IEnumerable).IsAssignableFrom(targetType) && targetType != typeof(string);
         if (isEnumerable && sanitized.StartsWith("{"))
         {
@@ -114,5 +116,107 @@ public static class JsonUtil
         }
 
         return sanitized;
+    }
+
+    internal static bool IsJsonQuote(char c)
+    {
+        return c == '"' || c == '“' || c == '”';
+    }
+
+    internal static bool IsLikelyStringTerminator(string text, int quoteIndex)
+    {
+        for (int i = quoteIndex + 1; i < text.Length; i++)
+        {
+            char c = text[i];
+            if (char.IsWhiteSpace(c))
+                continue;
+
+            return c == ',' || c == '}' || c == ']' || c == ':';
+        }
+
+        return true;
+    }
+
+    private static string ProtectMalformedQuotes(string text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+            return text;
+
+        var sb = new StringBuilder(text.Length + 16);
+        bool inString = false;
+        bool escaped = false;
+        char activeQuote = '\0';
+
+        for (int i = 0; i < text.Length; i++)
+        {
+            char c = text[i];
+
+            if (!inString)
+            {
+                if (IsJsonQuote(c))
+                {
+                    inString = true;
+                    activeQuote = c;
+                    sb.Append('"');
+                }
+                else
+                {
+                    sb.Append(c);
+                }
+
+                continue;
+            }
+
+            if (escaped)
+            {
+                sb.Append(c);
+                escaped = false;
+                continue;
+            }
+
+            if (c == '\\')
+            {
+                sb.Append(c);
+                escaped = true;
+                continue;
+            }
+
+            if (IsClosingQuoteForActiveString(activeQuote, c))
+            {
+                if (IsLikelyStringTerminator(text, i))
+                {
+                    sb.Append('"');
+                    inString = false;
+                    activeQuote = '\0';
+                }
+                else
+                {
+                    sb.Append("\\\"");
+                }
+
+                continue;
+            }
+
+            sb.Append(c);
+        }
+
+        if (inString)
+            sb.Append('"');
+
+        return sb.ToString();
+    }
+
+    private static bool IsClosingQuoteForActiveString(char activeQuote, char current)
+    {
+        if (activeQuote == '"')
+            return current == '"';
+
+        if (activeQuote == '“')
+            return current == '”' || current == '“' || current == '"';
+
+        if (activeQuote == '”')
+            return current == '”' || current == '“' || current == '"';
+
+        return current == '"';
     }
 }


### PR DESCRIPTION
## Content
Added quote-protection.

In [JsonUtil.cs](/c:/D/MODS/RimTalk/Source/Util/JsonUtil.cs), JSON is now sanitized before deserialization to repair common LLM quote errors:
- smart quotes like `“name”` are normalized to standard JSON quotes
- unescaped inner quotes inside string values are converted to `\"`
- unterminated strings are closed defensively when possible

In [JsonStreamParser.cs](/c:/D/MODS/RimTalk/Source/Util/JsonStreamParser.cs), the stream brace-matcher now understands smart quotes and avoids treating inner malformed quotes as real string terminators. It also uses `TryDeserializeFromJson()` instead of throwing and rethrowing parse exceptions.

The goal is to prevent malformed JSON quote output from escaping into Unity’s unhandled exception path and crashing the game.

PTAL.