### PR TITLE
feat: prompt template structural enhancements and lossless preset serialization

### DIFF
--- a/Source/Prompt/Data/PromptEntry.cs
+++ b/Source/Prompt/Data/PromptEntry.cs
@@ -120,7 +120,34 @@ public class PromptEntry : IExposable
     {
         Scribe_Values.Look(ref _id, "id", Guid.NewGuid().ToString());
         Scribe_Values.Look(ref _name, "name", "New Prompt");
-        Scribe_Values.Look(ref Content, "content", "");
+
+        // Preserve exact whitespace and newlines which XML Scribe normally destroys
+        string savedContent = Content;
+        if (Scribe.mode == LoadSaveMode.Saving && !string.IsNullOrEmpty(Content))
+        {
+            savedContent = "B64:" + Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(Content));
+        }
+        
+        Scribe_Values.Look(ref savedContent, "content", "");
+        
+        if (Scribe.mode == LoadSaveMode.LoadingVars)
+        {
+            if (!string.IsNullOrEmpty(savedContent) && savedContent.StartsWith("B64:"))
+            {
+                try
+                {
+                    Content = System.Text.Encoding.UTF8.GetString(Convert.FromBase64String(savedContent.Substring(4)));
+                }
+                catch
+                {
+                    Content = savedContent;
+                }
+            }
+            else
+            {
+                Content = savedContent ?? "";
+            }
+        }
         Scribe_Values.Look(ref Role, "role", PromptRole.System);
         Scribe_Values.Look(ref CustomRole, "customRole", "");
         Scribe_Values.Look(ref Position, "position", PromptPosition.Relative);

--- a/Source/Prompt/Parser/PromptContext.cs
+++ b/Source/Prompt/Parser/PromptContext.cs
@@ -32,6 +32,12 @@ public class PromptContext
     /// <summary>Dialogue type description (monologue/conversation/urgent, etc.)</summary>
     public string DialogueType { get; set; }
     
+    /// <summary>Intent description</summary>
+    public string Intent { get; set; }
+    
+    /// <summary>Topic description</summary>
+    public string ConversationTopic { get; set; }
+    
     /// <summary>Dialogue status description (initiator's current state)</summary>
     public string DialogueStatus { get; set; }
     

--- a/Source/Prompt/Parser/ScribanParser.cs
+++ b/Source/Prompt/Parser/ScribanParser.cs
@@ -358,6 +358,8 @@ public static class ScribanParser
     private static object GetMagicContextValue(PromptContext context, string member) {
         return member.ToLowerInvariant() switch {
             "dialogue_type" or "dialoguetype" => context.DialogueType ?? "",
+            "intent" => context.Intent ?? "",
+            "conversation_topic" or "conversationtopic" => context.ConversationTopic ?? "",
             "dialogue_status" or "dialoguestatus" => context.DialogueStatus ?? "",
             "prompt" or "dialogue_prompt" or "dialogueprompt" => context.DialoguePrompt ?? "",
             "context" or "pawn_context" or "pawncontext" => context.PawnContext ?? "",

--- a/Source/Prompt/Parser/VariableDefinitions.cs
+++ b/Source/Prompt/Parser/VariableDefinitions.cs
@@ -76,7 +76,9 @@ public static class VariableDefinitions
         {
             ("prompt", "Full decorated prompt including time, weather, and location"),
             ("context", "Raw formatted string describing the initiator's details"),
-            ("ctx.DialogueType", "Type of dialogue (monologue, conversation, etc.)"),
+            ("ctx.DialogueType", "Combined string containing both the dialogue intent and the conversation topic"),
+            ("ctx.Intent", "The structural intent of the dialogue (e.g. 'short monologue' or 'starts conversation')"),
+            ("ctx.ConversationTopic", "The core subject or trigger of the interaction (e.g. mental break, downed in pain, or specific interaction text)"),
             ("ctx.DialogueStatus", "Current status of the dialogue"),
             ("ctx.PawnContext", "Formatted string describing the pawn"),
             ("ctx.UserPrompt", "The raw prompt from the user (if any)"),

--- a/Source/Prompt/PromptContextProvider.cs
+++ b/Source/Prompt/PromptContextProvider.cs
@@ -17,22 +17,22 @@ namespace RimTalk.Prompt;
 public static class PromptContextProvider
 {
     /// <summary>
-    /// Generates a description string of the dialogue type.
-    /// Used by {{dialogue.type}} variable.
+    /// Generates a description string of the dialogue type, intent, and topic.
+    /// Used by {{dialogue.type}}, {{intent}}, and {{conversation.topic}} variables.
     /// Delegates to ContextBuilder.BuildDialogueType() to avoid code duplication.
     /// </summary>
-    public static string GetDialogueTypeString(TalkRequest talkRequest, List<Pawn> pawns)
+    public static (string dialogueType, string intent, string topic) GetDialogueTypeData(TalkRequest talkRequest, List<Pawn> pawns)
     {
-        if (pawns == null || pawns.Count == 0) return "";
+        if (pawns == null || pawns.Count == 0) return ("", "", "");
         
         var mainPawn = pawns[0];
         var shortName = mainPawn.LabelShort;
         var sb = new StringBuilder();
         
         // Delegate to ContextBuilder to avoid duplicating dialogue type logic
-        ContextBuilder.BuildDialogueType(sb, talkRequest, pawns, shortName, mainPawn);
+        ContextBuilder.BuildDialogueType(sb, talkRequest, pawns, shortName, mainPawn, out string intent, out string topic);
         
-        return sb.ToString();
+        return (sb.ToString(), intent, topic);
     }
 
     /// <summary>

--- a/Source/Prompt/PromptManager.cs
+++ b/Source/Prompt/PromptManager.cs
@@ -357,13 +357,15 @@ public class PromptManager : IExposable
         var settings = Settings.Get();
         
         // 1. Prepare shared context data
-        string dialogueType = PromptContextProvider.GetDialogueTypeString(talkRequest, pawns);
+        var (dialogueType, intent, topic) = PromptContextProvider.GetDialogueTypeData(talkRequest, pawns);
         talkRequest.Context = PromptService.BuildContext(pawns);
         PromptService.DecoratePrompt(talkRequest, pawns, status);
 
         // 2. Build Context Object
         var context = PromptContext.FromTalkRequest(talkRequest, pawns);
         context.DialogueType = dialogueType;
+        context.Intent = intent;
+        context.ConversationTopic = topic;
         context.DialogueStatus = status;
         context.DialoguePrompt = talkRequest.Prompt;
         LastContext = context;

--- a/Source/Service/ContextBuilder.cs
+++ b/Source/Service/ContextBuilder.cs
@@ -302,22 +302,32 @@ public static class ContextBuilder
 
     public static void BuildDialogueType(StringBuilder sb, TalkRequest talkRequest, List<Pawn> pawns, string shortName, Pawn mainPawn)
     {
+        BuildDialogueType(sb, talkRequest, pawns, shortName, mainPawn, out _, out _);
+    }
+
+    public static void BuildDialogueType(StringBuilder sb, TalkRequest talkRequest, List<Pawn> pawns, string shortName, Pawn mainPawn, out string intent, out string topic)
+    {
+        var intentSb = new StringBuilder();
+        var topicSb = new StringBuilder();
+
         if (talkRequest.TalkType.IsFromUser())
         {
-            sb.Append($"{pawns[1].LabelShort}({pawns[1].GetRole()}) said to {shortName}: '{talkRequest.Prompt}'. ");
+            topicSb.Append($"{pawns[1].LabelShort}({pawns[1].GetRole()}) said to {shortName}: '{talkRequest.Prompt}'. ");
 
             var mode = Settings.Get().PlayerDialogueMode;
             bool multiTurn = mode == Settings.PlayerDialogueMode.AIDriven || (!pawns[1].IsPlayer() && mode != Settings.PlayerDialogueMode.Manual);
 
-            sb.Append(multiTurn
+            intentSb.Append(multiTurn
                 ? $"Generate multi turn dialogues starting after this (do not repeat initial dialogue), beginning with {shortName}"
                 : $"Generate dialogue starting after this. Do not generate any further lines for {pawns[1].LabelShort}");
+
+            sb.Append(topicSb).Append(intentSb);
         }
         else
         {
             if (pawns.Count == 1)
             {
-                sb.Append($"{shortName} short monologue");
+                intentSb.Append($"{shortName} short monologue");
             }
             else if (mainPawn.IsInCombat() || mainPawn.GetMapRole() == MapRole.Invading)
             {
@@ -325,22 +335,29 @@ public static class ContextBuilder
                     talkRequest.Prompt = null;
 
                 talkRequest.TalkType = TalkType.Urgent;
-                sb.Append(mainPawn.IsSlave || mainPawn.IsPrisoner
+                intentSb.Append(mainPawn.IsSlave || mainPawn.IsPrisoner
                     ? $"{shortName} dialogue short (worry)"
                     : $"{shortName} dialogue short, urgent tone ({mainPawn.GetMapRole().ToString().ToLower()}/command)");
             }
             else
             {
-                sb.Append($"{shortName} starts conversation, taking turns");
+                intentSb.Append($"{shortName} starts conversation, taking turns");
             }
 
             if (mainPawn.InMentalState)
-                sb.Append("\nbe dramatic (mental break)");
+                topicSb.Append("be dramatic (mental break)");
             else if (mainPawn.Downed && !mainPawn.IsBaby())
-                sb.Append("\n(downed in pain. Short, strained dialogue)");
-            else
-                sb.Append($"\n{talkRequest.Prompt}");
+                topicSb.Append("(downed in pain. Short, strained dialogue)");
+            else if (talkRequest.Prompt != null)
+                topicSb.Append(talkRequest.Prompt);
+
+            sb.Append(intentSb);
+            if (topicSb.Length > 0)
+                sb.Append("\n").Append(topicSb);
         }
+
+        intent = intentSb.ToString();
+        topic = topicSb.ToString();
     }
 
     public static void BuildLocationContext(StringBuilder sb, ContextSettings contextSettings, Pawn mainPawn)

--- a/Source/Util/CommonUtil.cs
+++ b/Source/Util/CommonUtil.cs
@@ -196,4 +196,23 @@ public static class CommonUtil
     
         return text;
     }
+
+    public static string[] SplitByLine(string text)
+    {
+        if (string.IsNullOrEmpty(text))
+            return Array.Empty<string>();
+            
+        return text.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
+    }
+    
+    public static string[] SplitByString(string text, string separator)
+    {
+        if (string.IsNullOrEmpty(text))
+            return Array.Empty<string>();
+            
+        if (string.IsNullOrEmpty(separator))
+            return new[] { text };
+            
+        return text.Split(new[] { separator }, StringSplitOptions.None);
+    }
 }


### PR DESCRIPTION
## Overview
This PR overhauls the prompt context generation system to provide finer, more explicit control over AI behavioral rules and dialogue topics within Scriban templates. Additionally, it addresses a persistent issue where RimWorld's core XML parser consumed literal newlines and whitespaces inside custom presets upon loading.

  ## Key Changes

  ### 1. Granular Prompt Context (`Intent` & `ConversationTopic`)
  `DialogueType` historically functioned as a concatenated string that muddled behavioral intent and situational context. This has been decoupled into two distinct variables while maintaining full backwards compatibility for any templates relying on `ctx.DialogueType`.
  * Extracted `intent` (e.g., `"short monologue"`, `"starts conversation"`) and `topic` (e.g., `"mental break"`, interaction log data) directly within `ContextBuilder.BuildDialogueType`.
  * Added `ctx.Intent` and `ctx.ConversationTopic` as standalone properties in `PromptContext`.
  * Registered the new properties to `ScribanParser` (`ctx.intent`, `ctx.conversation_topic`) and defined them in the UI variable cheat-sheet (`VariableDefinitions`).

  ### 2. Lossless PromptPreset Serialization
  RimWorld's `Scribe` XML system notoriously sanitizes node strings, destroying leading/trailing whitespace and literal newlines, which broke Scriban structural hacks (like the `{{~ "" }}` empty string trick).
  * Refactored `PromptEntry.ExposeData()` to automatically Base64-encode template strings before they hit the XML stream. This completely shields all formatting from the XML parser.
  * Implemented a `B64:` prefix fallback layer that seamlessly decodes existing/legacy plain-text preset XMLs.
  * **Note:** The JSON exporter still outputs plain readable strings for external sharing and manual VSCode editing.

  ### 3. Native Scriban Text Splitters
  Added two new string manipulation utilities to `CommonUtil` specifically for Scriban array operations, reducing the need for obscure newline variable hacks.
  * Added `SplitByLine` and `SplitByString` functions.
  * Easily slice prompt payloads in templates via standard piping: `{{ profile_text | SplitByLine }}`.