### PR TITLE
Feat: added fullinteraction to get log entries

### DIFF
--- a/Source/API/ContextCategories.cs
+++ b/Source/API/ContextCategories.cs
@@ -33,6 +33,7 @@ public static class ContextCategories
         public static readonly ContextCategory Social = new("social", ContextType.Pawn);
         public static readonly ContextCategory FullSocial = new("fullsocial", ContextType.Pawn);
         public static readonly ContextCategory FullRelation = new("fullrelation", ContextType.Pawn);
+        public static readonly ContextCategory FullInteraction = new("fullinteraction", ContextType.Pawn);
         public static readonly ContextCategory FullThought = new("fullthought", ContextType.Pawn);
         public static readonly ContextCategory Equipment = new("equipment", ContextType.Pawn);
         public static readonly ContextCategory Genes = new("genes", ContextType.Pawn);

--- a/Source/Prompt/Parser/ScribanParser.cs
+++ b/Source/Prompt/Parser/ScribanParser.cs
@@ -324,6 +324,7 @@ public static class ScribanParser
             "social" => RelationsService.GetRelationsString(pawn),
             "fullsocial" => RelationsService.GetAllSocialString(pawn),
             "fullrelation" => RelationsService.GetAllRelationsString(pawn),
+            "fullinteraction" => RelationsService.GetAllInteractionString(pawn),
             "location" => PromptContextProvider.GetLocationString(pawn),
             "terrain" => pawn.Map != null ? pawn.Position.GetTerrain(pawn.Map)?.LabelCap ?? "" : "",
             "beauty" => PromptContextProvider.GetBeautyString(pawn),

--- a/Source/Service/RelationService.cs
+++ b/Source/Service/RelationService.cs
@@ -171,10 +171,8 @@ public static class RelationsService
         // Also filter out rimtalk history, as this is already handled by a different context
         var entries = Find.PlayLog.AllEntries
         .Where(entry =>
-            entry is PlayLogEntry_Interaction &&
             entry.Concerns(pawn) &&
             entry.GetType() != typeof(PlayLogEntry_RimTalkInteraction))
-        .Reverse()
         .Take(maxEntries);
         
         foreach (var entry in entries)
@@ -204,7 +202,7 @@ public static class RelationsService
 
         if (sb.Length > 0)
         {
-            return "Interaction Logs:\n" + sb.ToString().TrimEnd();
+            return "Interaction logs:\n" + sb.ToString().TrimEnd();
         }
 
         return "";

--- a/Source/Service/RelationService.cs
+++ b/Source/Service/RelationService.cs
@@ -165,8 +165,7 @@ public static class RelationsService
     {
         if (pawn == null || Find.PlayLog?.AllEntries == null) return "";
 
-        const int maxEntries = 5; // Todo make into a setting?
-
+        const int maxEntries = 5;
         var sb = new StringBuilder();
 
         // Also filter out rimtalk history, as this is already handled by a different context
@@ -194,12 +193,8 @@ public static class RelationsService
                 .Replace("\r", " ")
                 .Trim();
 
-                Log.Message(entry.GetType().ToString());
-                Log.Message(text);
-
                 sb.Append("- ");
                 sb.AppendLine(text);
-
             }
             catch (Exception)
             {   

--- a/Source/Service/RelationService.cs
+++ b/Source/Service/RelationService.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using RimTalk.Util;
 using RimWorld;
 using Verse;
@@ -155,6 +156,60 @@ public static class RelationsService
         {
             sb.Length -= 2;
             return "Relations: " + sb;
+        }
+
+        return "";
+    }
+
+    public static string GetAllInteractionString(Pawn pawn)
+    {
+        if (pawn == null || Find.PlayLog?.AllEntries == null) return "";
+
+        const int maxEntries = 5; // Todo make into a setting?
+
+        var sb = new StringBuilder();
+
+        // Also filter out rimtalk history, as this is already handled by a different context
+        var entries = Find.PlayLog.AllEntries
+        .Where(entry =>
+            entry is PlayLogEntry_Interaction &&
+            entry.Concerns(pawn) &&
+            entry.GetType() != typeof(PlayLogEntry_RimTalkInteraction))
+        .Reverse()
+        .Take(maxEntries);
+        
+        foreach (var entry in entries)
+        {
+            try
+            {
+                string text = entry.ToGameStringFromPOV(pawn, false).ToString();
+
+                // Remove string color codes
+                text = Regex.Replace(text, @"<.+?>", "");
+
+                // Also remove any newlines in the middle if they exist
+                text = text
+                .Replace("\r\n", " ")
+                .Replace("\n", " ")
+                .Replace("\r", " ")
+                .Trim();
+
+                Log.Message(entry.GetType().ToString());
+                Log.Message(text);
+
+                sb.Append("- ");
+                sb.AppendLine(text);
+
+            }
+            catch (Exception)
+            {   
+                // Skip if something's wrong with the entry (e.g., modded entry)
+            }
+        }
+
+        if (sb.Length > 0)
+        {
+            return "Interaction Logs:\n" + sb.ToString().TrimEnd();
         }
 
         return "";


### PR DESCRIPTION
I've added `fullinteraction`. 

`{{ pawn.fullinteraction }}` output example:

```
Interaction Logs:
- Alva joked about poker with Nerdi.
- Oh! The sunrise was so pretty today, wasn't it? I like it here!
- Alva chatted about hickory trees with Nerdi.
- Hee hee! You're funny, Tail. Want to watch the clouds with me?
- Yay! That one looks like a muffalo! Can you see it?
```

To avoid repeating `history` it filters out all RimTalk log entries. 

I've limited the number of interactions to the most recent 5. Maybe this could be a setting in the future? 
I'm also not sure if this is the most "token efficient" way to add this text, anyone with more knowledge should advise.

Related: #94 