### PR TITLE
fix: make PawnState TalkResponses thread-safe

### DIFF
--- a/Source/Data/PawnState.cs
+++ b/Source/Data/PawnState.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using RimTalk.Source.Data;
 using RimTalk.Util;
@@ -15,6 +16,7 @@ public class PawnState(Pawn pawn)
     public string LastStatus { get; set; } = "";
     public int RejectCount { get; set; }
     public readonly List<TalkResponse> TalkResponses = [];
+    private readonly ConcurrentQueue<TalkResponse> _incomingTalkResponses = new();
     public bool IsGeneratingTalk { get; set; }
     public readonly LinkedList<TalkRequest> TalkRequests = [];
     
@@ -86,6 +88,26 @@ public class PawnState(Pawn pawn)
     {
         TalkRequestPool.AddToHistory(request, RequestStatus.Processed);
         TalkRequests.Remove(request);
+    }
+
+    /// <summary>
+    /// Thread-safe hand-off for background threads to submit a talk response. Call
+    /// <see cref="DrainIncomingTalkResponses"/> from the main thread before reading
+    /// <see cref="TalkResponses"/> to move queued entries in.
+    /// </summary>
+    public void QueueIncomingResponse(TalkResponse talkResponse)
+    {
+        _incomingTalkResponses.Enqueue(talkResponse);
+    }
+
+    /// <summary>
+    /// Moves any responses queued from background threads into <see cref="TalkResponses"/>.
+    /// Must only be called from the main thread.
+    /// </summary>
+    public void DrainIncomingTalkResponses()
+    {
+        while (_incomingTalkResponses.TryDequeue(out var talkResponse))
+            TalkResponses.Add(talkResponse);
     }
 
     public bool CanDisplayTalk()

--- a/Source/Data/PawnState.cs
+++ b/Source/Data/PawnState.cs
@@ -128,23 +128,25 @@ public class PawnState(Pawn pawn)
     public bool CanGenerateTalk()
     {
         if (Pawn.IsPlayer()) return true;
-        return !IsGeneratingTalk && CanDisplayTalk() && Pawn.Awake() && TalkResponses.Empty() 
+        DrainIncomingTalkResponses();
+        return !IsGeneratingTalk && CanDisplayTalk() && Pawn.Awake() && TalkResponses.Empty()
                && CommonUtil.HasPassed(LastTalkTick, RimTalkSettings.ReplyInterval);
     }
-    
+
     public void IgnoreTalkResponse()
     {
         if (TalkResponses.Count == 0) return;
         var talkResponse = TalkResponses[0];
         TalkHistory.AddIgnored(talkResponse.Id);
         TalkResponses.Remove(talkResponse);
-        
+
         var log = ApiHistory.GetApiLog(talkResponse.Id);
         if (log != null) log.SpokenTick = -1;
     }
 
     public void IgnoreAllTalkResponses(List<TalkType> keepTypes = null)
     {
+        DrainIncomingTalkResponses();
         if (keepTypes == null)
             while (TalkResponses.Count > 0)
                 IgnoreTalkResponse();

--- a/Source/Service/TalkService.cs
+++ b/Source/Service/TalkService.cs
@@ -65,6 +65,7 @@ public static class TalkService
             .Concat(nearbyPawns.Where(p =>
             {
                 var pawnState = Cache.Get(p);
+                pawnState.DrainIncomingTalkResponses();
                 return pawnState.CanDisplayTalk() && pawnState.TalkResponses.Empty();
             }))
             .Distinct()
@@ -163,13 +164,17 @@ public static class TalkService
     /// </summary>
     public static void DisplayTalk()
     {
+        // Drain all pawns upfront so every pawn has a consistent view of TalkResponses for this tick cycle.
+        foreach (Pawn pawn in Cache.Keys)
+        {
+            Cache.Get(pawn)?.DrainIncomingTalkResponses();
+        }
+
         foreach (Pawn pawn in Cache.Keys)
         {
             PawnState pawnState = Cache.Get(pawn);
             if (pawnState == null) continue;
 
-            // Move any responses handed off from background generation threads before reading.
-            pawnState.DrainIncomingTalkResponses();
             if (pawnState.TalkResponses.Empty()) continue;
 
             var talk = pawnState.TalkResponses.First();
@@ -211,6 +216,7 @@ public static class TalkService
         PawnState pawnState = Cache.Get(pawn);
         if (pawnState == null) return null;
 
+        pawnState.DrainIncomingTalkResponses();
         TalkResponse talkResponse = ConsumeTalk(pawnState);
         pawnState.LastTalkTick = GenTicks.TicksGame;
 
@@ -274,6 +280,10 @@ public static class TalkService
 
     private static bool AnyPawnHasPendingResponses()
     {
-        return Cache.GetAll().Any(pawnState => pawnState.TalkResponses.Count > 0);
+        return Cache.GetAll().Any(pawnState =>
+        {
+            pawnState.DrainIncomingTalkResponses();
+            return pawnState.TalkResponses.Count > 0;
+        });
     }
 }

--- a/Source/Service/TalkService.cs
+++ b/Source/Service/TalkService.cs
@@ -122,8 +122,8 @@ public static class TalkService
 
                     receivedResponses.Add(talkResponse);
 
-                    // Enqueue the received talk for the pawn to display later.
-                    pawnState.TalkResponses.Add(talkResponse);
+                    // Hand off to the main thread for display later; PawnState.TalkResponses itself must only ever be touched from the main thread.
+                    pawnState.QueueIncomingResponse(talkResponse);
                 }
             );
 
@@ -166,7 +166,11 @@ public static class TalkService
         foreach (Pawn pawn in Cache.Keys)
         {
             PawnState pawnState = Cache.Get(pawn);
-            if (pawnState == null || pawnState.TalkResponses.Empty()) continue;
+            if (pawnState == null) continue;
+
+            // Move any responses handed off from background generation threads before reading.
+            pawnState.DrainIncomingTalkResponses();
+            if (pawnState.TalkResponses.Empty()) continue;
 
             var talk = pawnState.TalkResponses.First();
             if (talk == null)


### PR DESCRIPTION
Fixes #99 in accordance to what I wrote in the issue, manually tested on my machine, no duplicate messages after an hour of playtime on a new colony and default settings (except for local model and lowering AI cooldown down to 1s)