### PR TITLE
fix: regist `random` function

### DIFF
--- a/Source/Prompt/Parser/ScribanParser.cs
+++ b/Source/Prompt/Parser/ScribanParser.cs
@@ -70,6 +70,7 @@ public static class ScribanParser
             // 2.1 Session variable functions (cross-entry variables)
 			scriptObject.Import("setvar", new Action<string, object>(SetSessionVar));
 			scriptObject.Import("getvar", new Func<string, object>(GetSessionVar));
+			scriptObject.Import("random", new Func<int, int, int>((min, max) => UnityEngine.Random.Range(min, max)));
 
             // 2. IMPORT UTILITIES (Extension Methods support)
             // This allows: {{ pawn | IsTalkEligible }} or {{ GetRole pawn }}


### PR DESCRIPTION
And a random function for preset authors.

Now preset could call `UnityEngine.Random.Range(int, int)` as 

```c#
{{ random 1 11}}
```

PTAL.