### PR TITLE
fix: add omitted variables in `ScibanParser`

### DIFF
--- a/Source/Prompt/Parser/ScribanParser.cs
+++ b/Source/Prompt/Parser/ScribanParser.cs
@@ -86,25 +86,12 @@ public static class ScribanParser
             // 3. ROOT PROPERTIES & SYSTEM
             scriptObject.Add("lang", Constant.Lang);
             
-            // Time & Date shorthands
-            var ticks = Find.TickManager.TicksAbs;
-            if (context.Map != null)
-            {
-                var longLat = Find.WorldGrid.LongLatOf(context.Map.Tile);
-                scriptObject.Add("hour", GenDate.HourOfDay(ticks, longLat.x));
-                scriptObject.Add("day", GenDate.DayOfQuadrum(ticks, longLat.x) + 1);
-                scriptObject.Add("quadrum", GenDate.Quadrum(ticks, longLat.x).Label());
-                scriptObject.Add("year", GenDate.Year(ticks, longLat.x));
-                scriptObject.Add("season", GenLocalDate.Season(context.Map).Label());
-            }
-            else
-            {
-                scriptObject.Add("hour", GenDate.HourOfDay(ticks, 0));
-                scriptObject.Add("day", GenDate.DayOfQuadrum(ticks, 0) + 1);
-                scriptObject.Add("quadrum", GenDate.Quadrum(ticks, 0).Label());
-                scriptObject.Add("year", GenDate.Year(ticks, 0));
-                scriptObject.Add("season", Season.Undefined.Label());
-            }
+            // Structured game state plus convenient root aliases.
+            // Keep `date` under `game` because `date` is a Scriban builtin object.
+            var game = CreateGameState(context.Map);
+            scriptObject.Add("game", game);
+            foreach (var name in new[] { "time", "hour", "day", "quadrum", "year", "season", "weather", "temperature", "wealth" })
+                scriptObject.Add(name, game[name]);
             
             var json = new ScriptObject();
             json.Add("format", Constant.GetJsonInstruction(Settings.Get().ApplyMoodAndSocialEffects));
@@ -113,6 +100,7 @@ public static class ScribanParser
             var chat = new ScriptObject();
             string historyText = GetChatHistoryText(context);
             chat.Add("history", historyText);
+            chat.Add("history_simplified", GetChatHistoryText(context, simplified: true));
             scriptObject.Add("chat", chat);
             
             // 4. SHORTHANDS
@@ -335,10 +323,53 @@ public static class ScribanParser
         };
     }
 
+    private static ScriptObject CreateGameState(Map map)
+    {
+        var game = new ScriptObject();
+        var ticks = Find.TickManager?.TicksAbs ?? 0;
+        var longLat = map != null && Find.WorldGrid != null
+            ? Find.WorldGrid.LongLatOf(map.Tile)
+            : Vector2.zero;
+
+        game.Add("time", ApplyEnvironmentHook(map, ContextCategories.Environment.Time,
+            CommonUtil.GetInGameHour12HString(ticks, longLat)));
+        game.Add("hour", GenDate.HourOfDay(ticks, longLat.x));
+        game.Add("date", ApplyEnvironmentHook(map, ContextCategories.Environment.Date,
+            GenDate.DateFullStringAt(ticks, longLat)));
+        game.Add("day", GenDate.DayOfQuadrum(ticks, longLat.x) + 1);
+        game.Add("quadrum", GenDate.Quadrum(ticks, longLat.x).Label());
+        game.Add("year", GenDate.Year(ticks, longLat.x));
+        game.Add("season", ApplyEnvironmentHook(map, ContextCategories.Environment.Season,
+            map != null ? GenDate.Season(ticks, longLat).Label() : Season.Undefined.Label()));
+        game.Add("weather", ApplyEnvironmentHook(map, ContextCategories.Environment.Weather,
+            map?.weatherManager?.curWeather?.label ?? ""));
+        game.Add("temperature", ApplyEnvironmentHook(map, ContextCategories.Environment.Temperature,
+            map != null ? Mathf.RoundToInt(map.mapTemperature.OutdoorTemp).ToString() : ""));
+        game.Add("wealth", ApplyEnvironmentHook(map, ContextCategories.Environment.Wealth,
+            map?.wealthWatcher != null ? Describer.Wealth(map.wealthWatcher.WealthTotal) : ""));
+        return game;
+    }
+
+    private static string ApplyEnvironmentHook(Map map, ContextCategory category, string value)
+    {
+        return map != null
+            ? ContextHookRegistry.ApplyEnvironmentHooks(category, map, value ?? "")
+            : value ?? "";
+    }
+
     private static string GetMagicMapValue(Map map, string member) {
+        var ticks = Find.TickManager?.TicksAbs ?? 0;
+        var longLat = map != null && Find.WorldGrid != null
+            ? Find.WorldGrid.LongLatOf(map.Tile)
+            : Vector2.zero;
+
         return member.ToLowerInvariant() switch {
+            "time" => CommonUtil.GetInGameHour12HString(ticks, longLat),
+            "date" => GenDate.DateFullStringAt(ticks, longLat),
+            "season" => map != null ? GenDate.Season(ticks, longLat).Label() : Season.Undefined.Label(),
             "weather" => map.weatherManager?.curWeather?.label ?? "",
             "temperature" => Mathf.RoundToInt(map.mapTemperature.OutdoorTemp).ToString(),
+            "wealth" => map?.wealthWatcher != null ? Describer.Wealth(map.wealthWatcher.WealthTotal) : "",
             _ => null
         };
     }
@@ -375,11 +406,12 @@ public static class ScribanParser
         };
     }
 
-    private static string GetChatHistoryText(PromptContext context)
+    private static string GetChatHistoryText(PromptContext context, bool simplified = false)
     {
-        if (context.ChatHistory != null && context.ChatHistory.Count > 0)
+        var history = simplified ? context.GetChatHistory(true) : context.ChatHistory;
+        if (history != null && history.Count > 0)
         {
-            var lines = context.ChatHistory.Select((h, i) =>
+            var lines = history.Select((h, i) =>
             {
                 var text = (h.message ?? "").Replace("\r\n", " ").Replace("\n", " ").Replace("\r", " ");
                 return $"- {i + 1} | role={h.role} | text={text}";

--- a/Source/Prompt/Parser/VariableDefinitions.cs
+++ b/Source/Prompt/Parser/VariableDefinitions.cs
@@ -36,8 +36,18 @@ public static class VariableDefinitions
         RootTypeMap["prompt"] = typeof(string);
         RootTypeMap["context"] = typeof(string);
         RootTypeMap["settings"] = typeof(RimTalkSettings);
+        RootTypeMap["game"] = typeof(ScriptObject);
         RootTypeMap["json"] = typeof(ScriptObject);
         RootTypeMap["chat"] = typeof(ScriptObject);
+        RootTypeMap["time"] = typeof(string);
+        RootTypeMap["hour"] = typeof(int);
+        RootTypeMap["day"] = typeof(int);
+        RootTypeMap["quadrum"] = typeof(string);
+        RootTypeMap["year"] = typeof(int);
+        RootTypeMap["season"] = typeof(string);
+        RootTypeMap["weather"] = typeof(string);
+        RootTypeMap["temperature"] = typeof(string);
+        RootTypeMap["wealth"] = typeof(string);
 
         // 4. Auto-populate from PromptContext (imported properties)
         foreach (var prop in typeof(PromptContext).GetProperties(BindingFlags.Public | BindingFlags.Instance))
@@ -68,6 +78,7 @@ public static class VariableDefinitions
             ("recipient", "The character being spoken to (if any)"),
             ("pawns", "List of all pawns in the dialogue"),
             ("map", "The current map object"),
+            ("game", "Structured local game time and environment state"),
             ("ctx", "The full prompt context object"),
             ("settings", "RimTalk mod settings")
         };
@@ -88,7 +99,23 @@ public static class VariableDefinitions
             ("ctx.history", "Alias of chat.history"),
             ("ctx.talk_type", "Alias of ctx.TalkType"),
             ("ctx.pawn_count", "Count of ctx.AllPawns"),
-            ("ctx.map_id", "Map uniqueID")
+            ("ctx.map_id", "Map uniqueID"),
+            ("time", "Local in-game time, such as 3pm (alias of game.time)"),
+            ("hour", "Local hour as an integer from 0 to 23 (alias of game.hour)"),
+            ("game.date", "Full local in-game date; kept under game to preserve Scriban's date builtin"),
+            ("day", "Day of the current quadrum, from 1 to 15 (alias of game.day)"),
+            ("quadrum", "Current quadrum label (alias of game.quadrum)"),
+            ("year", "Current in-game year (alias of game.year)"),
+            ("season", "Current local season label (alias of game.season)"),
+            ("weather", "Current weather label (alias of game.weather)"),
+            ("temperature", "Current outdoor temperature in Celsius (alias of game.temperature)"),
+            ("wealth", "Current map wealth description (alias of game.wealth)"),
+            ("map.time", "Local in-game time with environment hooks applied"),
+            ("map.date", "Full local in-game date with environment hooks applied"),
+            ("map.season", "Local season with environment hooks applied"),
+            ("map.weather", "Current weather with environment hooks applied"),
+            ("map.temperature", "Current outdoor temperature with environment hooks applied"),
+            ("map.wealth", "Current map wealth description with environment hooks applied")
         };
         
         // 3.5 Game Static Classes
@@ -112,7 +139,11 @@ public static class VariableDefinitions
         var customVars = ContextHookRegistry.GetAllCustomVariables().ToList();
         if (customVars.Any())
         {
-            var modVarsList = customVars.Select(v => (v.Name, $"[{v.Type}] {v.Description} (from {v.ModId})")).ToList();
+            var modVarsList = customVars.Select(v =>
+            {
+                var name = v.Type == "Environment" ? $"map.{v.Name}" : v.Name;
+                return (name, $"[{v.Type}] {v.Description} (from {v.ModId})");
+            }).ToList();
             dict["RimTalk.Settings.PromptPreset.ModVariables".Translate()] = modVarsList;
         }
 


### PR DESCRIPTION
## Content

Add omitted variables in `ScibanParser` so that Scriban prompts could fully cover `Source\Service\ContextBuilder.cs`.

The newly increased variables are listed as following:

```
{{ time }}         # e.g. 3pm
{{ hour }}         # int 0–23
{{ day }}          # int 1–15
{{ quadrum }}
{{ year }}
{{ season }}
{{ weather }}
{{ temperature }}
{{ wealth }}
```

Users could call these variables in Scriban as:

```
{{ if hour >= 6 && hour < 12 }}
The colonists are working.
{{ else if hour >= 18 }}
The colonists are going to entertain themselves.
{{ end }}
```

PTAL.