### PR TITLE
fix: route AIErrorHandler messages through main-thread queue

### DIFF
--- a/Source/Error/TalkErrorHandler.cs
+++ b/Source/Error/TalkErrorHandler.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Threading.Tasks;
 using RimTalk.Util;
 using RimWorld;
@@ -9,6 +10,22 @@ namespace RimTalk.Error;
 public static class AIErrorHandler
 {
     private static bool _quotaWarningShown;
+    private static readonly ConcurrentQueue<Action> PendingMessages = new();
+
+    public static void DrainPendingMessages()
+    {
+        while (PendingMessages.TryDequeue(out var action))
+        {
+            try
+            {
+                action();
+            }
+            catch (Exception ex) // Don't let one bad message stop the rest of the queue draining
+            {
+                Logger.Warning($"Failed to display queued message: {ex.Message}");
+            }
+        }
+    }
 
     public static async Task<T> HandleWithRetry<T>(Func<Task<T>> operation, Action<Exception> onFailure = null)
     {
@@ -85,23 +102,32 @@ public static class AIErrorHandler
         if (!_quotaWarningShown)
         {
             _quotaWarningShown = true;
-            string message = "RimTalk.TalkService.QuotaExceeded".Translate();
-            Messages.Message(message, MessageTypeDefOf.NeutralEvent, false);
             Logger.Warning(ex.Message);
+            PendingMessages.Enqueue(() =>
+            {
+                string message = "RimTalk.TalkService.QuotaExceeded".Translate();
+                Messages.Message(message, MessageTypeDefOf.NeutralEvent, false);
+            });
         }
     }
 
     private static void ShowGenerationWarning(Exception ex)
     {
         Logger.Warning(ex.StackTrace);
-        string message = $"{"RimTalk.TalkService.GenerationFailed".Translate()}: {ex.Message}";
-        Messages.Message(message, MessageTypeDefOf.NeutralEvent, false);
+        PendingMessages.Enqueue(() =>
+        {
+            string message = $"{"RimTalk.TalkService.GenerationFailed".Translate()}: {ex.Message}";
+            Messages.Message(message, MessageTypeDefOf.NeutralEvent, false);
+        });
     }
 
     private static void ShowRetryMessage(Exception ex, string nextModel)
     {
-        string messageKey = ex is QuotaExceededException ? "RimTalk.TalkService.QuotaReached" : "RimTalk.TalkService.APIError";
-        string message = $"{messageKey.Translate()}. {"RimTalk.TalkService.TryingNextAPI".Translate(nextModel)}";
-        Messages.Message(message, MessageTypeDefOf.NeutralEvent, false);
+        PendingMessages.Enqueue(() =>
+        {
+            string messageKey = ex is QuotaExceededException ? "RimTalk.TalkService.QuotaReached" : "RimTalk.TalkService.APIError";
+            string message = $"{messageKey.Translate()}. {"RimTalk.TalkService.TryingNextAPI".Translate(nextModel)}";
+            Messages.Message(message, MessageTypeDefOf.NeutralEvent, false);
+        });
     }
 }

--- a/Source/Patch/TickManagerPatch.cs
+++ b/Source/Patch/TickManagerPatch.cs
@@ -1,5 +1,6 @@
 using HarmonyLib;
 using RimTalk.Data;
+using RimTalk.Error;
 using RimTalk.Service;
 using RimTalk.Source.Data;
 using RimTalk.Util;
@@ -23,6 +24,8 @@ internal static class TickManagerPatch
     public static void Postfix()
     {
         Counter.Tick++;
+
+        AIErrorHandler.DrainPendingMessages();
 
         if (IsNow(DebugStatUpdateInterval))
         {


### PR DESCRIPTION
## Summary

`AIErrorHandler` (`Source/Error/TalkErrorHandler.cs`) was calling `Messages.Message` directly from whatever thread invoked `HandleWithRetry`, for talk generation, always a background thread-pool thread, never the main game thread. This has been fixed by routing those calls through a queue drained on the main thread.

## Where the freeze came from

`TalkService.GenerateTalk` dispatches via `Task.Run(...)` (`Source/Service/TalkService.cs:91`). Nothing downstream marshals back to the main thread, `GenerateAndProcessTalkAsync` -> `AIService.ChatStreaming` -> `AIService.ExecuteWithRetry` -> `AIErrorHandler.HandleWithRetry` (`TalkErrorHandler.cs:30`) all continue on thread-pool threads (no `SynchronizationContext` capture, unlike `Source/Settings/Settings_Api.cs:467`).

On final failure, `HandleFinalFailure` (`TalkErrorHandler.cs:83`), still on the background thread, called `Messages.Message(...)` directly from `ShowQuotaWarning`, `ShowGenerationWarning`, and `ShowRetryMessage`.

`Messages.Message` mutates Verse's global on-screen message list, which the main thread reads/draws every frame, a background thread writing into that with no synchronization races the main thread. Symptom: the game doesn't crash, it just stops responding.

Pattern was present since `6553e1f feat: Adds dedicated AI error handling and fallback model support`.

## Validation

Confirmed against `Source/` at `43ac005` and the shipped `Assembly-CSharp.dll` (disassembled via `monodis`):

- `Verse.Messages.Message` mutates an unsynchronized static `List<Message> liveMessages` via `Add`/`RemoveAt`, no lock. Main thread mutates/reads it every frame (`Messages.Update()`, `MessagesDoGUI()`). This confirmed an unsynchronized cross-thread `List<T>` mutation once `AIErrorHandler` called in from a background thread.
- The fix pattern (background enqueues, main thread drains on tick) already existed elsewhere in this codebase as precedent: `PawnState._incomingTalkResponses` (`ConcurrentQueue<TalkResponse>`), enqueued via `QueueIncomingResponse`, drained via `DrainIncomingTalkResponses()` from `TickManagerPatch.Postfix` on `TickManager.DoSingleTick`.

## Fix applied

`Source/Error/TalkErrorHandler.cs`:

- Added `private static readonly ConcurrentQueue<Action> PendingMessages = new();`.
- Added `public static void DrainPendingMessages()`, which dequeues and invokes each queued action, catching and logging any exception so one bad message can't stop the rest of the queue draining.
- `ShowQuotaWarning`, `ShowGenerationWarning`, and `ShowRetryMessage` no longer call `Messages.Message`/`.Translate()` inline; each now enqueues a closure that does the translate-and-display work, to be run later on the main thread.

`Source/Patch/TickManagerPatch.cs`:

- `Postfix` calls `AIErrorHandler.DrainPendingMessages()` unconditionally as its first action, before the `IsNow(DebugStatUpdateInterval)` check and before the `!Settings.Get().IsEnabled || Find.CurrentMap == null` early-return, so a pending message can't sit undelivered while disabled or between maps.

No other call sites needed to change; this was the only place error/status messages were raised from a background thread.

## Evidence

Originally observed as a full game freeze w/o any further log output, coinciding with a `TimeoutException` from `OpenAIClient.SendRequestAsync` at `Source/Client/OpenAI/OpenAIClient.cs:212` propagating through `AIService.ChatStreaming` -> `AIErrorHandler.HandleWithRetry` at `TalkErrorHandler.cs:30`. The timeout itself is expected (60s stalled-generation read timeout); it was `HandleFinalFailure`'s subsequent `Messages.Message` calls on that same background thread that triggered the freeze.

## Suggested verification

- Force a generation request to fail (e.g. point the API config at a slow endpoint) while the game is actively ticking/drawing.
- Trigger several failures in close succession, previously this increased odds of a background `Messages.Message` call landing mid-frame.
- Confirm the game stays responsive and the queued message/toast still appears (drained on the next tick) instead of the game hanging.