### PR TITLE
fix: port five standalone bug fixes from jkraybill/RimTalk

### DIFF
--- a/Source/Data/PawnState.cs
+++ b/Source/Data/PawnState.cs
@@ -17,7 +17,15 @@ public class PawnState(Pawn pawn)
     public int RejectCount { get; set; }
     public readonly List<TalkResponse> TalkResponses = [];
     private readonly ConcurrentQueue<TalkResponse> _incomingTalkResponses = new();
-    public bool IsGeneratingTalk { get; set; }
+    // Same hazard as AIService._busy: set on the main thread, cleared in a finally on a
+    // threadpool thread. An auto-property gives no memory barrier, so a stale `true` here
+    // would silence this pawn for good.
+    private volatile bool _isGeneratingTalk;
+    public bool IsGeneratingTalk
+    {
+        get => _isGeneratingTalk;
+        set => _isGeneratingTalk = value;
+    }
     public readonly LinkedList<TalkRequest> TalkRequests = [];
     
     public HashSet<Hediff> Hediffs { get; set; } = pawn.GetHediffs();

--- a/Source/Error/TalkErrorHandler.cs
+++ b/Source/Error/TalkErrorHandler.cs
@@ -105,7 +105,7 @@ public static class AIErrorHandler
             Logger.Warning(ex.Message);
             PendingMessages.Enqueue(() =>
             {
-                string message = "RimTalk.TalkService.QuotaExceeded".Translate();
+                string message = "RimTalk.TalkService.QuotaReached".Translate();
                 Messages.Message(message, MessageTypeDefOf.NeutralEvent, false);
             });
         }

--- a/Source/Prompt/PromptManager.cs
+++ b/Source/Prompt/PromptManager.cs
@@ -395,15 +395,23 @@ public class PromptManager : IExposable
         // 4. Reset session variables and build
         ScribanParser.ResetSessionVariables();
         var segments = new List<PromptMessageSegment>();
-        var messages = BuildMessagesFromPreset(preset, context, segments);
-        
-        if (baseEntry != null && originalBaseContent != null)
+        List<(PromptRole role, string content)> messages;
+        try
         {
-            baseEntry.Content = originalBaseContent;
+            messages = BuildMessagesFromPreset(preset, context, segments);
         }
-        
+        finally
+        {
+            // Simple mode overwrites the saved Base Instruction to render it; restore it even
+            // if rendering throws, or the preset is left permanently holding the simple-mode text.
+            if (baseEntry != null && originalBaseContent != null)
+            {
+                baseEntry.Content = originalBaseContent;
+            }
+        }
+
         talkRequest.PromptMessageSegments = segments.Count > 0 ? segments : null;
-        
+
         return messages.Select(m => ((Role)m.role, m.content)).ToList();
     }
 

--- a/Source/Service/AIService.cs
+++ b/Source/Service/AIService.cs
@@ -14,7 +14,10 @@ namespace RimTalk.Service;
 // In most cases, you should NOT modify this file.
 public static class AIService
 {
-    private static bool _busy;
+    // volatile: written in an async finally on a threadpool thread, read on the main thread every
+    // tick. Without it the main thread can cache a stale `true` and dialogue stops silently for good.
+    private static volatile bool _busy;
+    private static DateTime? _busySince;
     private static bool _firstInstruction = true;
 
     /// <summary>
@@ -87,6 +90,7 @@ public static class AIService
     private static async Task<Payload> ExecuteWithRetry(ApiLog apiLog, Func<IAIClient, Task<Payload>> action)
     {
         _busy = true;
+        _busySince = DateTime.Now;
         try
         {
             Exception capturedEx = null;
@@ -120,6 +124,7 @@ public static class AIService
         finally
         {
             _busy = false;
+            _busySince = null;
         }
     }
 
@@ -144,10 +149,21 @@ public static class AIService
     }
 
     public static bool IsFirstInstruction() => _firstInstruction;
-    public static bool IsBusy() => _busy;
+    public static bool IsBusy()
+    {
+        if (!BusyGate.IsStuck(_busy, _busySince, DateTime.Now)) return _busy;
+
+        Logger.Warning($"The AI slot has been held for over {BusyGate.StuckAfterSeconds}s. " +
+                       "Releasing it - no request can legitimately take that long, and while it " +
+                       "is held nobody in the colony can speak.");
+        _busy = false;
+        _busySince = null;
+        return false;
+    }
     public static void Clear()
     {
         _busy = false;
+        _busySince = null;
         _firstInstruction = true;
     }
 }

--- a/Source/Service/BusyGate.cs
+++ b/Source/Service/BusyGate.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace RimTalk.Service;
+
+// Backstop for AIService's busy flag: if it's been held longer than any request could
+// legitimately take, treat it as stuck and release it rather than staying silent forever.
+public static class BusyGate
+{
+    // Client allows 60s connect + 60s read inactivity, plus retries on top, so a slow
+    // model on a bad connection can take minutes. 300s is well past that.
+    public const int StuckAfterSeconds = 300;
+
+    public static bool IsStuck(bool busy, DateTime? busySince, DateTime now,
+                               int stuckAfterSeconds = StuckAfterSeconds)
+    {
+        if (!busy) return false;
+
+        // No stamp means nobody recorded the start; don't clear a request we know nothing about.
+        if (busySince == null) return false;
+
+        return (now - busySince.Value).TotalSeconds >= stuckAfterSeconds;
+    }
+}

--- a/Source/Service/CustomDialogueService.cs
+++ b/Source/Service/CustomDialogueService.cs
@@ -48,6 +48,8 @@ public static class CustomDialogueService
 
     public static bool CanTalk(Pawn initiator, Pawn recipient)
     {
+        if (initiator == null || recipient == null) return false;
+
         // Player talking to a pawn is always allowed
         if (initiator.IsPlayer()) return true;
 

--- a/Source/Service/TalkService.cs
+++ b/Source/Service/TalkService.cs
@@ -44,7 +44,10 @@ public static class TalkService
         }
 
         List<Pawn> nearbyPawns = PawnSelector.GetAllNearByPawns(talkRequest.Initiator, isAnnouncement: talkRequest.IsAnnouncement);
-        if (talkRequest.Recipient.IsPlayer()) nearbyPawns.Insert(0, talkRequest.Recipient);
+        // Recipient may have just been nulled above; guard explicitly so a null pawn
+        // doesn't get inserted into nearbyPawns and NRE downstream.
+        if (talkRequest.Recipient != null && talkRequest.Recipient.IsPlayer())
+            nearbyPawns.Insert(0, talkRequest.Recipient);
         var (status, isInDanger) = talkRequest.Initiator.GetPawnStatusFull(nearbyPawns);
         
         // Avoid spamming generations if the pawn's status hasn't changed recently.

--- a/Source/Settings/Settings_Api.cs
+++ b/Source/Settings/Settings_Api.cs
@@ -453,7 +453,13 @@ public partial class Settings
 
             if (models != null && models.Any())
             {
-                options.AddRange(models.Select(model => new FloatMenuOption(model, () => config.SelectedModel = model)));
+                // Sorted here (not in FetchModelsAsync) so the cached path benefits too.
+                // OpenRouter alone returns 400+ models in whatever order its API feels like.
+                var sorted = models
+                    .OrderBy(model => model, StringComparer.OrdinalIgnoreCase)
+                    .ThenBy(model => model, StringComparer.Ordinal);
+
+                options.AddRange(sorted.Select(model => new FloatMenuOption(model, () => config.SelectedModel = model)));
             }
             else
             {

--- a/Source/UI/PersonaEditorWindow.cs
+++ b/Source/UI/PersonaEditorWindow.cs
@@ -1,6 +1,7 @@
 using RimTalk.Data;
 using RimWorld;
 using UnityEngine;
+using System.Threading.Tasks;
 using Verse;
 
 namespace RimTalk.UI;
@@ -149,11 +150,17 @@ public class PersonaEditorWindow : Window
                 Data.PersonaService.GeneratePersona(_pawn).ContinueWith(task =>
                 {
                     _isGenerating = false;
-                    if (task.IsCompleted)
+
+                    // IsCompleted is also true for Faulted/Canceled, and task.Result would NRE then.
+                    var result = task.Status == TaskStatus.RanToCompletion ? task.Result : null;
+                    if (result == null)
                     {
-                        _editingPersonality = task.Result.Persona ?? "";
-                        _talkInitiationWeight = task.Result.Chattiness;
+                        Util.Logger.Warning("Persona generation failed - see the API log.");
+                        return;
                     }
+
+                    _editingPersonality = result.Persona ?? "";
+                    _talkInitiationWeight = result.Chattiness;
                 });
             }
         }

--- a/Source/Util/PawnUtil.cs
+++ b/Source/Util/PawnUtil.cs
@@ -15,6 +15,7 @@ public static class PawnUtil
 {
     public static bool IsTalkEligible(this Pawn pawn)
     {
+        if (pawn == null) return false;
         if (pawn.IsPlayer()) return true;
         if (pawn.HasVocalLink()) return true;
         if (pawn.DestroyedOrNull() || !pawn.Spawned || pawn.Dead) return false;
@@ -621,12 +622,15 @@ public static class PawnUtil
 
     public static bool IsPlayer(this Pawn pawn)
     {
-        return pawn == Cache.GetPlayer();
+        // Cache.GetPlayer() is null until the invisible player pawn is created, so without
+        // the null guard every null pawn would count as "the player".
+        return pawn != null && pawn == Cache.GetPlayer();
     }
 
     public static bool HasVocalLink(this Pawn pawn)
     {
         return Settings.Get().AllowNonHumanToTalk &&
+               pawn?.health?.hediffSet != null &&
                pawn.health.hediffSet.HasHediff(Constant.VocalLinkDef);
     }
 }

--- a/Source/Util/PawnUtil.cs
+++ b/Source/Util/PawnUtil.cs
@@ -43,7 +43,8 @@ public static class PawnUtil
         if (pawn == null || pawn.IsPlayer()) return false;
         if (pawn.Dead) return true;
         if (pawn.Downed) return true;
-        if (!pawn.health.capacities.CapableOf(PawnCapacityDefOf.Moving)) return true;
+        // Being unable to walk is a condition, not a danger - genuine danger to an immobile
+        // pawn is already covered by the hostile/bleeding/pain/burning/hediff checks below.
         if (pawn.InMentalState && includeMentalState) return true;
         if (pawn.IsBurning()) return true;
         if (pawn.health.hediffSet.PainTotal >= pawn.GetStatValue(StatDefOf.PainShockThreshold)) return true;
@@ -66,13 +67,26 @@ public static class PawnUtil
     {
         if (pawn == null) return false;
 
-        if (pawn.mindState.enemyTarget != null) return true;
+        // enemyTarget is sticky - RimWorld doesn't reliably clear it when a fight ends and it
+        // survives save/reload, so a raw null check marks anyone who's ever fought as permanently
+        // in combat. Only count it while the target is still a live threat.
+        var target = pawn.mindState?.enemyTarget;
+        if (IsLiveThreat(pawn, target)) return true;
 
         if (pawn.stances?.curStance is Stance_Busy busy && busy.verb != null)
             return true;
 
         Pawn hostilePawn = pawn.GetHostilePawnNearBy();
         return hostilePawn != null && pawn.Position.DistanceTo(hostilePawn.Position) <= 20f;
+    }
+
+    /// <summary>A remembered target only counts while it is still there and still a threat.</summary>
+    private static bool IsLiveThreat(Pawn pawn, Thing target)
+    {
+        if (target == null || target.Destroyed || !target.Spawned) return false;
+        if (target.Map != pawn.Map) return false;
+        if (target is Pawn tp && (tp.Dead || tp.Downed)) return false;
+        return pawn.Position.DistanceTo(target.Position) <= 30f;
     }
 
     public static string GetRole(this Pawn pawn, bool includeFaction = false)


### PR DESCRIPTION
Ports five small, self-contained bug fixes from jkraybill/RimTalk. The fork's larger Narrative/Goals/Prose rewrite is out of scope.

License/attribution: jkraybill/RimTalk is CC BY-NC-SA 4.0. Each commit is tagged `Ported from jkraybill/RimTalk@<sha>`, authored by "Gordo <gordo@dashcord.com>".

All five re-verified against current code (7365f9c / v1.1.3) before porting.

## The five fixes

1. **Stale non-volatile busy flags can permanently silence dialogue.**
   `AIService._busy` / `PawnState.IsGeneratingTalk` are `static bool`s set on the main thread, cleared on a threadpool thread, no memory barrier -- tick loop can read a cached `true` forever. Marked `volatile`, added `BusyGate` as a 300s backstop.
   Files: `PawnState.cs`, `AIService.cs`, `BusyGate.cs` (new). Commit c584c65.

2. **Sticky enemyTarget / immobility permanently flag pawns as in danger/combat.**
   `IsInCombat` trusted `mindState.enemyTarget`, which doesn't reliably clear and survives save/reload. `IsInDanger` treated any non-`Moving`-capable pawn as permanently in danger. Fix: only count a live, on-map, nearby remembered target; dropped the immobility check (already covered elsewhere).
   Files: `PawnUtil.cs`. Commit dbedf12. Closes #65 and closes #78 

3. **Quota-exceeded message uses an undefined translation key.**
   `ShowQuotaWarning` referenced a key that exists in no language file; swapped for the correct existing key.
   Files: `TalkErrorHandler.cs`. Commit 1843993.

4. **Unsorted 400+ entry model dropdown.**
   OpenRouter model list is unordered. Sorted case-insensitively in `OpenMenu`; "Custom" stays appended last.
   Files: `Settings_Api.cs`. Commit be64ce1.

5. **Three latent crashes on the talk path.**
   - Null recipient: a null-safe `IsPlayer()` treated null-vs-null as `true`, letting a nulled `Recipient` slip into `nearbyPawns` and NRE downstream. Fixed at the call site and in `IsPlayer` itself; two more silently-reliant callers guarded.
   - Simple Mode preset corruption: Base Instruction restore after render wasn't in a `finally`, so a throw during Scriban render left the preset permanently corrupted.
   - Persona generation dereferenced a null/faulted Task result (`IsCompleted` is true for Faulted/Canceled too). Now checks `RanToCompletion` explicitly.
   Files: `PromptManager.cs`, `CustomDialogueService.cs`, `TalkService.cs`, `PersonaEditorWindow.cs`, `PawnUtil.cs`. Commit d21ecfb.

## Testing

`dotnet build RimTalk.csproj`: 0 errors after every commit and on final tree (13 pre-existing, unrelated `UnityWebRequest` obsolescence warnings).

Playtested and checked both `Player.log` and the session's dialogue-export CSV for regressions:
- One request failed at colony start; `_busy` released cleanly per fix 1, and no request failed silently afterward.
- No other errors, exceptions, empty/duplicate responses, or null-pawn entries in the rest of the session. Dialogue generation worked normally throughout.
- Fix 4 is unverified as I can't force a quota exceeded message on my own.