### PR TITLE
fix: fix overlay rich-text clipping and prioritize the latest dialogue

### DIFF
--- a/Source/Data/ApiHistory.cs
+++ b/Source/Data/ApiHistory.cs
@@ -49,12 +49,19 @@ public static class ApiHistory
 
     public static ApiLog AddResponse(Guid id, string response, string name, string interactionType, Payload payload = null, int elapsedMs = 0)
     {
+        return AddResponse(id, response, name, interactionType, payload, elapsedMs, null);
+    }
+
+    public static ApiLog AddResponse(Guid id, string response, string name, string interactionType, Payload payload,
+        int elapsedMs, string targetName)
+    {
         if (!History.TryGetValue(id, out var originalLog)) return null;
 
         // first message
         if (originalLog.Response == null)
         {
             originalLog.Name = name ?? originalLog.Name;
+            originalLog.TargetName = targetName;
             originalLog.Response = response;
             originalLog.InteractionType = interactionType;
             if (payload != null)
@@ -64,7 +71,10 @@ public static class ApiHistory
         }
         
         // multi-turn messages
-        var newLog = new ApiLog(name, originalLog.TalkRequest, response, payload, DateTime.Now, originalLog.Channel);
+        var newLog = new ApiLog(name, originalLog.TalkRequest, response, payload, DateTime.Now, originalLog.Channel)
+        {
+            TargetName = targetName
+        };
         History[newLog.Id] = newLog;
         newLog.InteractionType = interactionType;
         newLog.ElapsedMs = elapsedMs;
@@ -78,7 +88,10 @@ public static class ApiHistory
             ? $"{initiator.LabelShort} announced"
             : $"{initiator.LabelShort} talked to {recipient?.LabelShort}"; 
         TalkRequest talkRequest = new(prompt, initiator, recipient, talkType);
-        var log = new ApiLog(initiator.LabelShort, talkRequest, text, null, DateTime.Now, Channel.User);
+        var log = new ApiLog(initiator.LabelShort, talkRequest, text, null, DateTime.Now, Channel.User)
+        {
+            TargetName = recipient?.LabelShort
+        };
         History[log.Id] = log;
         return log;
     }

--- a/Source/Data/ApiLog.cs
+++ b/Source/Data/ApiLog.cs
@@ -18,6 +18,7 @@ public class ApiLog(string name, TalkRequest talkRequest, string response, Paylo
     public int ConversationId { get; set; }
     public TalkRequest TalkRequest { get; set; } = talkRequest ?? new TalkRequest(null, null);
     public string Name { get; set; } = name;
+    public string TargetName { get; set; }
     public string Response { get; set; } = response;
     public string InteractionType;
     public bool IsFirstDialogue;
@@ -50,6 +51,7 @@ public class ApiLog(string name, TalkRequest talkRequest, string response, Paylo
         var sb = new StringBuilder();
         sb.AppendLine($"Timestamp: {Timestamp:yyyy-MM-dd HH:mm:ss}");
         sb.AppendLine($"Pawn: {Name ?? "-"}");
+        sb.AppendLine($"Target: {TargetName ?? "-"}");
         sb.AppendLine($"InteractionType: {InteractionType ?? "-"}");
         sb.AppendLine($"ElapsedMs: {ElapsedMs}");
         sb.AppendLine($"TokenCount: {Payload?.TokenCount}");

--- a/Source/Service/AIService.cs
+++ b/Source/Service/AIService.cs
@@ -41,7 +41,8 @@ public static class AIService
                     if (lastApiLog == apiLog) elapsedMs -= lastApiLog.ElapsedMs;
 
                     var newLog = ApiHistory.AddResponse(apiLog.Id, response.Text, response.Name,
-                        response.InteractionRaw, elapsedMs: elapsedMs);
+                        response.InteractionRaw, payload: null, elapsedMs: elapsedMs,
+                        targetName: response.TargetName);
                     
                     response.Id = newLog.Id;
                     lastApiLog = newLog;

--- a/Source/UI/Overlay.cs
+++ b/Source/UI/Overlay.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using HarmonyLib;
 using RimTalk.Data;
 using RimTalk.Source.Data;
@@ -21,11 +22,21 @@ public class Overlay : MapComponent
 
     private class CachedMessageLine
     {
+        // Kept for compatibility with extensions which inspect RimTalk's overlay cache.
         public string PawnName;
+        public Pawn PawnInstance;
+
+        public string SpeakerName;
+        public string TargetName;
+        public Pawn TargetPawnInstance;
         public string Dialogue;
+        public float LeftBracketWidth;
+        public float SpeakerWidth;
+        public float DirectionWidth;
+        public float TargetWidth;
+        public float RightBracketWidth;
         public float NameWidth;
         public float LineHeight;
-        public Pawn PawnInstance;
         public TalkType TalkType;
         public bool IsUserEntered;
     }
@@ -49,7 +60,13 @@ public class Overlay : MapComponent
     private const float DropdownWidth = 200f;
     private const float DropdownHeight = 255f;
     private const int MaxMessagesInLog = 10;
-    private const float TextPadding = 5f; 
+    private const float TextPadding = 5f;
+    private const string LeftBracket = "[";
+    private const string Direction = " -> ";
+    private const string RightBracket = "]";
+
+    private static bool _externalDialogueFormatterResolved;
+    private static MethodInfo _externalDialogueFormatter;
 
     private static readonly Color AnnounceBgColor = new(0.8f, 0.5f, 0.0f, 0.18f);
     private static readonly Color AnnounceNameColor = new(1.0f, 0.78f, 0.2f);
@@ -65,6 +82,88 @@ public class Overlay : MapComponent
     private void MarkCacheAsDirty()
     {
         _isCacheDirty = true;
+    }
+
+    private static string BuildFinalRichText(string text)
+    {
+        text ??= string.Empty;
+
+        if (!_externalDialogueFormatterResolved)
+        {
+            _externalDialogueFormatterResolved = true;
+            var formatterType = AccessTools.TypeByName("RimTalkDynamicColors.DynamicColorMod");
+            var formatter = formatterType == null
+                ? null
+                : AccessTools.Method(formatterType, "ColorizeString", [typeof(string)]);
+
+            if (formatter is { IsStatic: true } && formatter.ReturnType == typeof(string))
+            {
+                _externalDialogueFormatter = formatter;
+            }
+        }
+
+        if (_externalDialogueFormatter == null) return text;
+
+        try
+        {
+            return _externalDialogueFormatter.Invoke(null, [text]) as string ?? text;
+        }
+        catch
+        {
+            // A compatibility formatter must never prevent the overlay from rendering.
+            _externalDialogueFormatter = null;
+            return text;
+        }
+    }
+
+    private static void SplitParticipantNames(string combinedName, string explicitTargetName,
+        out string speakerName, out string targetName)
+    {
+        string candidate = TrimOuterBrackets(combinedName);
+        targetName = TrimOuterBrackets(explicitTargetName);
+
+        int separatorIndex = candidate.IndexOf("->", StringComparison.Ordinal);
+        int separatorLength = 2;
+        if (separatorIndex < 0)
+        {
+            separatorIndex = candidate.IndexOf('→');
+            separatorLength = 1;
+        }
+
+        if (separatorIndex > 0 && separatorIndex + separatorLength < candidate.Length)
+        {
+            speakerName = candidate[..separatorIndex].Trim();
+            if (string.IsNullOrWhiteSpace(targetName))
+            {
+                targetName = candidate[(separatorIndex + separatorLength)..].Trim();
+            }
+        }
+        else
+        {
+            speakerName = candidate;
+        }
+
+        if (string.IsNullOrWhiteSpace(speakerName)) speakerName = "Unknown";
+        if (string.IsNullOrWhiteSpace(targetName)) targetName = null;
+    }
+
+    private static string TrimOuterBrackets(string value)
+    {
+        value = value?.Trim() ?? string.Empty;
+        return value.Length >= 2 && value[0] == '[' && value[^1] == ']'
+            ? value[1..^1].Trim()
+            : value;
+    }
+
+    private static Pawn FindPawn(string pawnName)
+    {
+        if (string.IsNullOrWhiteSpace(pawnName)) return null;
+
+        return Cache.GetByName(pawnName)?.Pawn ??
+               Find.CurrentMap?.mapPawns?.AllPawns?.FirstOrDefault(p =>
+                   p?.Name?.ToStringShort == pawnName) ??
+               Find.WorldPawns?.AllPawnsAliveOrDead.FirstOrDefault(p =>
+                   p?.Name?.ToStringShort == pawnName);
     }
 
     public override void MapRemoved()
@@ -100,40 +199,42 @@ public class Overlay : MapComponent
 
             foreach (var message in messages)
             {
-                string pawnName = message.Name ?? "Unknown";
-                string dialogue = message.Response ?? "";
-                string formattedName = $"[{pawnName}]";
-                
-                float nameWidth = Text.CalcSize(formattedName).x;
-                float availableDialogueWidth = contentWidth - nameWidth - TextPadding;
-                
-                if (availableDialogueWidth < 0)
-                {
-                    availableDialogueWidth = contentWidth * 0.5f;
-                }
-                
-                const float safetyMargin = 3f;
-                float dialogueWidthForCalc = Mathf.Max(0f, availableDialogueWidth - safetyMargin);
-                
-                float dialogueHeight = Text.CalcHeight(dialogue, dialogueWidthForCalc);
-                float nameHeight = Text.CalcHeight(formattedName, nameWidth);
-                float lineHeight = Mathf.Max(dialogueHeight, nameHeight);
-                
-                lineHeight += 2f;
+                SplitParticipantNames(message.Name, message.TargetName, out string speakerName, out string targetName);
 
-                var foundPawn = Cache.GetByName(pawnName)?.Pawn ??
-                                Find.CurrentMap?.mapPawns?.AllPawns?.FirstOrDefault(p =>
-                                    p?.Name?.ToStringShort == pawnName) ??
-                                Find.WorldPawns?.AllPawnsAliveOrDead.FirstOrDefault(p =>
-                                    p?.Name?.ToStringShort == pawnName);
+                // Generate rich text before measuring it. The exact cached string is also used for drawing.
+                string dialogue = BuildFinalRichText(message.Response);
+
+                float leftBracketWidth = Text.CalcSize(LeftBracket).x;
+                float speakerWidth = Text.CalcSize(speakerName).x;
+                float directionWidth = targetName == null ? 0f : Text.CalcSize(Direction).x;
+                float targetWidth = targetName == null ? 0f : Text.CalcSize(targetName).x;
+                float rightBracketWidth = Text.CalcSize(RightBracket).x;
+                float nameWidth = leftBracketWidth + speakerWidth + directionWidth + targetWidth + rightBracketWidth;
+                float availableDialogueWidth = contentWidth - nameWidth - TextPadding;
+                float dialogueWidthForCalc = Mathf.Max(1f, availableDialogueWidth);
+
+                float dialogueHeight = Text.CalcHeight(dialogue, dialogueWidthForCalc);
+                float nameHeight = Text.CalcSize(LeftBracket + speakerName +
+                    (targetName == null ? string.Empty : Direction + targetName) + RightBracket).y;
+                float lineHeight = Mathf.Max(dialogueHeight, nameHeight);
+
+                lineHeight += 2f;
 
                 newCache.Add(new CachedMessageLine
                 {
-                    PawnName = pawnName,
+                    PawnName = speakerName,
+                    PawnInstance = FindPawn(speakerName),
+                    SpeakerName = speakerName,
+                    TargetName = targetName,
+                    TargetPawnInstance = FindPawn(targetName),
                     Dialogue = dialogue,
+                    LeftBracketWidth = leftBracketWidth,
+                    SpeakerWidth = speakerWidth,
+                    DirectionWidth = directionWidth,
+                    TargetWidth = targetWidth,
+                    RightBracketWidth = rightBracketWidth,
                     NameWidth = nameWidth,
                     LineHeight = lineHeight,
-                    PawnInstance = foundPawn,
                     TalkType = message.TalkRequest?.TalkType ?? TalkType.Other,
                     IsUserEntered = message.Channel == Channel.User,
                 });
@@ -411,6 +512,37 @@ public class Overlay : MapComponent
         listing.End();
     }
 
+    private static void DrawCachedLabel(Rect rect, string text)
+    {
+        // Keep Widgets.Label outside DrawMessageLog so compatibility transpilers cannot
+        // transform the already measured rich text a second time at the call site.
+        Widgets.Label(rect, text);
+    }
+
+    private static void DrawParticipants(Rect rowRect, CachedMessageLine message)
+    {
+        float currentX = rowRect.x;
+
+        DrawCachedLabel(new Rect(currentX, rowRect.y, message.LeftBracketWidth, rowRect.height), LeftBracket);
+        currentX += message.LeftBracketWidth;
+
+        var speakerRect = new Rect(currentX, rowRect.y, message.SpeakerWidth, rowRect.height);
+        UIUtil.DrawClickablePawnName(speakerRect, message.SpeakerName, message.PawnInstance, false);
+        currentX += message.SpeakerWidth;
+
+        if (message.TargetName != null)
+        {
+            DrawCachedLabel(new Rect(currentX, rowRect.y, message.DirectionWidth, rowRect.height), Direction);
+            currentX += message.DirectionWidth;
+
+            var targetRect = new Rect(currentX, rowRect.y, message.TargetWidth, rowRect.height);
+            UIUtil.DrawClickablePawnName(targetRect, message.TargetName, message.TargetPawnInstance, false);
+            currentX += message.TargetWidth;
+        }
+
+        DrawCachedLabel(new Rect(currentX, rowRect.y, message.RightBracketWidth, rowRect.height), RightBracket);
+    }
+
     private void DrawMessageLog(Rect inRect)
     {
         if (_isCacheDirty)
@@ -442,32 +574,32 @@ public class Overlay : MapComponent
                 if (currentY < contentRect.y) break;
 
                 var rowRect = new Rect(contentRect.x, currentY, contentRect.width, message.LineHeight);
-                var nameRect = new Rect(rowRect.x, rowRect.y, message.NameWidth, rowRect.height);
-                float totalDialogueSpace = Mathf.Max(0f, rowRect.width - message.NameWidth);
-                var dialogueRect = new Rect(nameRect.xMax + TextPadding, rowRect.y, totalDialogueSpace - TextPadding, rowRect.height);
+                float dialogueWidth = Mathf.Max(1f, rowRect.width - message.NameWidth - TextPadding);
+                var dialogueRect = new Rect(rowRect.x + message.NameWidth + TextPadding, rowRect.y,
+                    dialogueWidth, rowRect.height);
 
                 // Only the text that user enters gets highlighted
                 if (message.IsUserEntered && message.TalkType == TalkType.Announcement)
                 {
                     Widgets.DrawBoxSolid(rowRect, AnnounceBgColor);
                     GUI.color = AnnounceNameColor;
-                    UIUtil.DrawClickablePawnName(nameRect, message.PawnName, message.PawnInstance);
+                    DrawParticipants(rowRect, message);
                     GUI.color = AnnounceTextColor;
-                    Widgets.Label(dialogueRect, message.Dialogue);
+                    DrawCachedLabel(dialogueRect, message.Dialogue);
                     GUI.color = Color.white;
                 }
                 else if (message.IsUserEntered && message.TalkType == TalkType.User)
                 {
                     GUI.color = UserNameColor;
-                    UIUtil.DrawClickablePawnName(nameRect, message.PawnName, message.PawnInstance);
+                    DrawParticipants(rowRect, message);
                     GUI.color = UserTextColor;
-                    Widgets.Label(dialogueRect, message.Dialogue);
+                    DrawCachedLabel(dialogueRect, message.Dialogue);
                     GUI.color = Color.white;
                 }
                 else
                 {
-                    UIUtil.DrawClickablePawnName(nameRect, message.PawnName, message.PawnInstance);
-                    Widgets.Label(dialogueRect, message.Dialogue);
+                    DrawParticipants(rowRect, message);
+                    DrawCachedLabel(dialogueRect, message.Dialogue);
                 }
             }
         }

--- a/Source/UI/Overlay.cs
+++ b/Source/UI/Overlay.cs
@@ -27,8 +27,11 @@ public class Overlay : MapComponent
         public Pawn PawnInstance;
 
         public string SpeakerName;
+        public string SpeakerLabel;
         public string TargetName;
+        public string TargetLabel;
         public Pawn TargetPawnInstance;
+        public string RawDialogue;
         public string Dialogue;
         public float LeftBracketWidth;
         public float SpeakerWidth;
@@ -61,6 +64,9 @@ public class Overlay : MapComponent
     private const float DropdownHeight = 255f;
     private const int MaxMessagesInLog = 10;
     private const float TextPadding = 5f;
+    private const float MaxNameColumnFraction = 0.45f;
+    private const float MinimumDialogueWidth = 120f;
+    private const float LineVerticalPadding = 2f;
     private const string LeftBracket = "[";
     private const string Direction = " -> ";
     private const string RightBracket = "]";
@@ -166,6 +172,128 @@ public class Overlay : MapComponent
                    p?.Name?.ToStringShort == pawnName);
     }
 
+    private static float CalcRichTextHeight(string text, float width)
+    {
+        // Verse.Text.CalcHeight strips tags first. Calling the active GUIStyle directly
+        // makes measurement honor rich-text styles such as <b> exactly as GUI.Label does.
+        return Text.CurFontStyle.CalcHeight(new GUIContent(text ?? string.Empty), Mathf.Max(1f, width));
+    }
+
+    private static string ClampSingleLineWithEllipsis(string text, float maxWidth)
+    {
+        text ??= string.Empty;
+        if (Text.CalcSize(text).x <= maxWidth) return text;
+
+        const string ellipsis = "…";
+        if (Text.CalcSize(ellipsis).x > maxWidth) return string.Empty;
+
+        int low = 0;
+        int high = text.Length;
+        int bestLength = 0;
+        while (low <= high)
+        {
+            int middle = (low + high) / 2;
+            int safeLength = GetSafeSubstringLength(text, middle);
+            string candidate = text[..safeLength].TrimEnd() + ellipsis;
+            if (Text.CalcSize(candidate).x <= maxWidth)
+            {
+                bestLength = safeLength;
+                low = middle + 1;
+            }
+            else
+            {
+                high = middle - 1;
+            }
+        }
+
+        return text[..bestLength].TrimEnd() + ellipsis;
+    }
+
+    private static int GetSafeSubstringLength(string text, int length)
+    {
+        if (length > 0 && length < text.Length &&
+            char.IsHighSurrogate(text[length - 1]) && char.IsLowSurrogate(text[length]))
+        {
+            return length - 1;
+        }
+
+        return length;
+    }
+
+    private static string FitDialogueToHeight(string rawDialogue, float width, float maxHeight)
+    {
+        rawDialogue ??= string.Empty;
+        string fullDialogue = BuildFinalRichText(rawDialogue);
+        if (CalcRichTextHeight(fullDialogue, width) <= maxHeight) return fullDialogue;
+
+        const string ellipsis = "…";
+        string bestDialogue = BuildFinalRichText(ellipsis);
+        int low = 0;
+        int high = rawDialogue.Length;
+
+        while (low <= high)
+        {
+            int middle = (low + high) / 2;
+            int safeLength = GetSafeSubstringLength(rawDialogue, middle);
+            string candidate = rawDialogue[..safeLength].TrimEnd() + ellipsis;
+            string formattedCandidate = BuildFinalRichText(candidate);
+
+            if (CalcRichTextHeight(formattedCandidate, width) <= maxHeight)
+            {
+                bestDialogue = formattedCandidate;
+                low = middle + 1;
+            }
+            else
+            {
+                high = middle - 1;
+            }
+        }
+
+        return bestDialogue;
+    }
+
+    private static void CalculateParticipantLayout(string speakerName, string targetName, float maxNameWidth,
+        out string speakerLabel, out string targetLabel, out float leftBracketWidth, out float speakerWidth,
+        out float directionWidth, out float targetWidth, out float rightBracketWidth, out float nameWidth)
+    {
+        leftBracketWidth = Text.CalcSize(LeftBracket).x;
+        directionWidth = targetName == null ? 0f : Text.CalcSize(Direction).x;
+        rightBracketWidth = Text.CalcSize(RightBracket).x;
+
+        float availableNameWidth = Mathf.Max(1f,
+            maxNameWidth - leftBracketWidth - directionWidth - rightBracketWidth);
+        float naturalSpeakerWidth = Text.CalcSize(speakerName).x;
+        float naturalTargetWidth = targetName == null ? 0f : Text.CalcSize(targetName).x;
+
+        float speakerLimit = availableNameWidth;
+        float targetLimit = 0f;
+        if (targetName != null)
+        {
+            float halfWidth = availableNameWidth * 0.5f;
+            if (naturalSpeakerWidth <= halfWidth)
+            {
+                speakerLimit = naturalSpeakerWidth;
+                targetLimit = availableNameWidth - speakerLimit;
+            }
+            else if (naturalTargetWidth <= halfWidth)
+            {
+                targetLimit = naturalTargetWidth;
+                speakerLimit = availableNameWidth - targetLimit;
+            }
+            else
+            {
+                speakerLimit = halfWidth;
+                targetLimit = halfWidth;
+            }
+        }
+
+        speakerLabel = ClampSingleLineWithEllipsis(speakerName, speakerLimit);
+        targetLabel = targetName == null ? null : ClampSingleLineWithEllipsis(targetName, targetLimit);
+        speakerWidth = Text.CalcSize(speakerLabel).x;
+        targetWidth = targetLabel == null ? 0f : Text.CalcSize(targetLabel).x;
+        nameWidth = leftBracketWidth + speakerWidth + directionWidth + targetWidth + rightBracketWidth;
+    }
+
     public override void MapRemoved()
     {
         base.MapRemoved();
@@ -189,6 +317,10 @@ public class Overlay : MapComponent
             Text.Anchor = TextAnchor.UpperLeft;
 
             float contentWidth = settings.OverlayRectNonDebug.width - 10f;
+            float contentHeight = Mathf.Max(1f, settings.OverlayRectNonDebug.height - 10f);
+            float maxNameWidth = Mathf.Max(1f, Mathf.Min(
+                contentWidth * MaxNameColumnFraction,
+                contentWidth - MinimumDialogueWidth - TextPadding));
 
             var newCache = new List<CachedMessageLine>();
             var messages = allRequests
@@ -201,43 +333,61 @@ public class Overlay : MapComponent
             {
                 SplitParticipantNames(message.Name, message.TargetName, out string speakerName, out string targetName);
 
-                // Generate rich text before measuring it. The exact cached string is also used for drawing.
-                string dialogue = BuildFinalRichText(message.Response);
-
-                float leftBracketWidth = Text.CalcSize(LeftBracket).x;
-                float speakerWidth = Text.CalcSize(speakerName).x;
-                float directionWidth = targetName == null ? 0f : Text.CalcSize(Direction).x;
-                float targetWidth = targetName == null ? 0f : Text.CalcSize(targetName).x;
-                float rightBracketWidth = Text.CalcSize(RightBracket).x;
-                float nameWidth = leftBracketWidth + speakerWidth + directionWidth + targetWidth + rightBracketWidth;
-                float availableDialogueWidth = contentWidth - nameWidth - TextPadding;
-                float dialogueWidthForCalc = Mathf.Max(1f, availableDialogueWidth);
-
-                float dialogueHeight = Text.CalcHeight(dialogue, dialogueWidthForCalc);
-                float nameHeight = Text.CalcSize(LeftBracket + speakerName +
-                    (targetName == null ? string.Empty : Direction + targetName) + RightBracket).y;
-                float lineHeight = Mathf.Max(dialogueHeight, nameHeight);
-
-                lineHeight += 2f;
+                CalculateParticipantLayout(speakerName, targetName, maxNameWidth,
+                    out string speakerLabel, out string targetLabel,
+                    out float leftBracketWidth, out float speakerWidth, out float directionWidth,
+                    out float targetWidth, out float rightBracketWidth, out float nameWidth);
 
                 newCache.Add(new CachedMessageLine
                 {
                     PawnName = speakerName,
                     PawnInstance = FindPawn(speakerName),
                     SpeakerName = speakerName,
+                    SpeakerLabel = speakerLabel,
                     TargetName = targetName,
+                    TargetLabel = targetLabel,
                     TargetPawnInstance = FindPawn(targetName),
-                    Dialogue = dialogue,
+                    RawDialogue = message.Response ?? string.Empty,
                     LeftBracketWidth = leftBracketWidth,
                     SpeakerWidth = speakerWidth,
                     DirectionWidth = directionWidth,
                     TargetWidth = targetWidth,
                     RightBracketWidth = rightBracketWidth,
                     NameWidth = nameWidth,
-                    LineHeight = lineHeight,
                     TalkType = message.TalkRequest?.TalkType ?? TalkType.Other,
                     IsUserEntered = message.Channel == Channel.User,
                 });
+            }
+
+            if (newCache.Count > 0)
+            {
+                // Use one bounded name column for every row. This keeps the dialogue column
+                // aligned and prevents long participant names from covering dialogue text.
+                float nameColumnWidth = newCache.Max(line => line.NameWidth);
+                float dialogueWidth = Mathf.Max(1f, contentWidth - nameColumnWidth - TextPadding);
+                float maxLatestDialogueHeight = Mathf.Max(1f, contentHeight - LineVerticalPadding);
+
+                for (int i = 0; i < newCache.Count; i++)
+                {
+                    var line = newCache[i];
+                    line.NameWidth = nameColumnWidth;
+
+                    // The newest message gets the whole bubble first. Only truncate that
+                    // message when it cannot fit even with every older row omitted.
+                    line.Dialogue = i == 0
+                        ? FitDialogueToHeight(line.RawDialogue, dialogueWidth, maxLatestDialogueHeight)
+                        : BuildFinalRichText(line.RawDialogue);
+
+                    float dialogueHeight = CalcRichTextHeight(line.Dialogue, dialogueWidth);
+                    float nameHeight = Text.CalcSize(LeftBracket + line.SpeakerLabel +
+                        (line.TargetLabel == null ? string.Empty : Direction + line.TargetLabel) + RightBracket).y;
+                    line.LineHeight = Mathf.Max(dialogueHeight, nameHeight) + LineVerticalPadding;
+
+                    if (i == 0)
+                    {
+                        line.LineHeight = Mathf.Min(line.LineHeight, contentHeight);
+                    }
+                }
             }
 
             _cachedMessagesForLog = newCache;
@@ -527,7 +677,7 @@ public class Overlay : MapComponent
         currentX += message.LeftBracketWidth;
 
         var speakerRect = new Rect(currentX, rowRect.y, message.SpeakerWidth, rowRect.height);
-        UIUtil.DrawClickablePawnName(speakerRect, message.SpeakerName, message.PawnInstance, false);
+        UIUtil.DrawClickablePawnName(speakerRect, message.SpeakerLabel, message.PawnInstance, false);
         currentX += message.SpeakerWidth;
 
         if (message.TargetName != null)
@@ -536,7 +686,7 @@ public class Overlay : MapComponent
             currentX += message.DirectionWidth;
 
             var targetRect = new Rect(currentX, rowRect.y, message.TargetWidth, rowRect.height);
-            UIUtil.DrawClickablePawnName(targetRect, message.TargetName, message.TargetPawnInstance, false);
+            UIUtil.DrawClickablePawnName(targetRect, message.TargetLabel, message.TargetPawnInstance, false);
             currentX += message.TargetWidth;
         }
 
@@ -570,10 +720,15 @@ public class Overlay : MapComponent
             for (int i = 0; i < _cachedMessagesForLog.Count; i++)
             {
                 var message = _cachedMessagesForLog[i];
-                currentY -= message.LineHeight;
-                if (currentY < contentRect.y) break;
+                float remainingHeight = currentY - contentRect.y;
+                if (i > 0 && message.LineHeight > remainingHeight) break;
 
-                var rowRect = new Rect(contentRect.x, currentY, contentRect.width, message.LineHeight);
+                float rowHeight = i == 0
+                    ? Mathf.Min(message.LineHeight, remainingHeight)
+                    : message.LineHeight;
+                currentY -= rowHeight;
+
+                var rowRect = new Rect(contentRect.x, currentY, contentRect.width, rowHeight);
                 float dialogueWidth = Mathf.Max(1f, rowRect.width - message.NameWidth - TextPadding);
                 var dialogueRect = new Rect(rowRect.x + message.NameWidth + TextPadding, rowRect.y,
                     dialogueWidth, rowRect.height);

--- a/Source/UI/UIUtil.cs
+++ b/Source/UI/UIUtil.cs
@@ -19,8 +19,11 @@ public static class UIUtil
     /// <param name="rect">The rectangle area to draw in.</param>
     /// <param name="pawnName">The name of the pawn to display.</param>
     /// <param name="pawn">An optional direct reference to the pawn.</param>
-    public static void DrawClickablePawnName(Rect rect, string pawnName, Pawn pawn = null)
+    /// <param name="includeBrackets">Whether to include square brackets around the name.</param>
+    public static void DrawClickablePawnName(Rect rect, string pawnName, Pawn pawn = null, bool includeBrackets = true)
     {
+        string label = includeBrackets ? $"[{pawnName}]" : pawnName;
+
         if (pawn != null)
         {
             var originalColor = GUI.color;
@@ -31,7 +34,7 @@ public static class UIUtil
                 pawn.Dead ? Color.gray :
                 PawnNameColorUtility.PawnNameColorOf(pawn);
 
-            Widgets.Label(rect, $"[{pawnName}]");
+            Widgets.Label(rect, label);
 
             if (Widgets.ButtonInvisible(rect))
             {
@@ -49,7 +52,7 @@ public static class UIUtil
         }
         else
         {
-            Widgets.Label(rect, $"[{pawnName}]");
+            Widgets.Label(rect, label);
         }
     }
     


### PR DESCRIPTION
# Summary

This PR fixes dialogue clipping, column overlap, and inconsistent wrapping in the conversation overlay, especially when responses contain rich-text formatting or exceed the available overlay height.

It also separates speakers and dialogue targets into distinct fields so directed dialogue can be measured, rendered, and interacted with correctly.

# Bug

The bugs are reported by several users.

- bug1: cut offf response
<img width="370" height="350" alt="8ce0d1f71ad3b69c324f4d8911fba3ab" src="https://github.com/user-attachments/assets/f97ac9c5-19f5-4b38-8334-0a21bd667f19" />

- bug2: element overlapping
<img width="783" height="521" alt="6aa415ea4f390998fbe7edcaf1b30426" src="https://github.com/user-attachments/assets/5993cc23-13e8-4936-a3dd-aa6bb864e05a" />


# Changes

- Store the dialogue target separately from the speaker in API history.
- Pass `TalkResponse.TargetName` through the streaming response pipeline.
- Preserve backward compatibility with legacy `A -> B` and `A → B` composite names.
- Render speakers and targets as separate clickable fields.
- Generate the final rich-text string before calculating row height.
- Use the same cached rich-text string for measurement and rendering.
- Prevent compatibility patches from formatting dialogue a second time during rendering.
- Measure rich text through the active Unity `GUIStyle`, ensuring tags such as `<b>` are reflected in wrapping and height calculations.
- Add a bounded, aligned participant column to prevent names from overlapping dialogue.
- Truncate long speaker or target names with an ellipsis.
- Prioritize displaying the newest response in full.
- Truncate the newest response at the end only when it cannot fit by itself.
- Show older responses only when they fit completely in the remaining space, preventing partially clipped rows.
- Avoid splitting UTF-16 surrogate pairs during truncation.

# Compatibility

- Retains legacy overlay cache fields used by external extensions.
- Gracefully falls back to unformatted text if the Dynamic Colors formatter is unavailable or fails.
- Continues to support historical logs containing combined speaker and target names.

PTAL.