### PR TITLE
fix: fix several bugs found in v1.2.0

### DIFF
--- a/Source/Client/OpenAI/OpenAIClient.cs
+++ b/Source/Client/OpenAI/OpenAIClient.cs
@@ -23,7 +23,6 @@ public class OpenAIClient(
 {
     private const string DefaultPath = "/v1/chat/completions";
     private readonly string _endpointUrl = FormatEndpointUrl(baseUrl);
-    private readonly Random _random = new();
 
     private static string FormatEndpointUrl(string baseUrl)
     {
@@ -133,7 +132,7 @@ public class OpenAIClient(
                 mergedMessages.Add(new Message
                 {
                     Role = "user",
-                    Content = $"{_random.Next()} {systemText}"
+                    Content = systemText
                 });
                 rawMessages.RemoveAll(m => m.role == Role.System);
             }

--- a/Source/Data/Constant.cs
+++ b/Source/Data/Constant.cs
@@ -28,8 +28,33 @@ public static class Constant
          Visitor: polite, curious, deferential; treat other visitors in the same group as companions
          Enemy: hostile, aggressive; terse commands/threats
 
-         Monologue = 1 turn. Conversation = 4-8 short turns
+         Conversation = 4-8 short turns
          """;
+
+    public const string SimpleModeMonologueInstruction = "Monologue = 1 turn.";
+
+    /// <summary>
+    /// Removes the legacy built-in monologue limit. The limit is now injected only while
+    /// rendering Simple Mode, so Advanced Mode presets can control monologue length themselves.
+    /// </summary>
+    public static string RemoveLegacyMonologueTurnInstruction(string instruction)
+    {
+        if (string.IsNullOrWhiteSpace(instruction)) return instruction;
+
+        return instruction
+            .Replace(SimpleModeMonologueInstruction + " ", "")
+            .Replace(SimpleModeMonologueInstruction, "")
+            .TrimEnd();
+    }
+
+    public static string GetSimpleModeInstruction(string instruction)
+    {
+        string normalized = RemoveLegacyMonologueTurnInstruction(instruction);
+        if (string.IsNullOrWhiteSpace(normalized))
+            normalized = DefaultInstruction;
+
+        return $"{normalized.TrimEnd()}\n{SimpleModeMonologueInstruction}";
+    }
 
     public const string JsonInstruction = """
                                            Output JSONL.

--- a/Source/Patch/BubblePatch.cs
+++ b/Source/Patch/BubblePatch.cs
@@ -68,6 +68,12 @@ public static class Bubbler_Add
         if (pawnState == null || (isChitchat && pawnState.TalkRequests.Count > 0))
             return false;
 
+        // During the automatic dialogue cooldown, preserve the vanilla bubble instead of
+        // swallowing it and leaving a stale AI request queued for later. User-initiated talks
+        // remain exempt from the cooldown in TickManagerPatch.
+        if (AIService.IsBusy() || !TickManagerPatch.IsAutomaticTalkCooldownReady())
+            return true;
+
         // Otherwise, block normal bubble and generate talk
         prompt = $"{prompt} ({interactionDef.label})";
         pawnState.AddTalkRequest(prompt, recipient, isChitchat ? TalkType.Chitchat : TalkType.Interaction);

--- a/Source/Patch/TickManagerPatch.cs
+++ b/Source/Patch/TickManagerPatch.cs
@@ -90,15 +90,31 @@ internal static class TickManagerPatch
                     continue;
                 }
 
+                bool isUserInitiated = request.TalkType.IsFromUser();
+
                 if (AIService.IsBusy())
                 {
-                    if (AIService.CanCancelFor(request))
+                    // Keep the automatic cooldown anchored to the end of the active request.
+                    _lastTalkEndTick = GenTicks.TicksGame;
+
+                    // Automatic interactions must not bypass the cooldown by pre-empting another
+                    // automatic generation. Explicit user requests may still take priority.
+                    if (isUserInitiated && AIService.CanCancelFor(request))
                         AIService.CancelCurrent();
                     return;
                 }
 
-                TalkService.GenerateTalk(request);
-                UserRequestPool.Remove(pawn);
+                if (!isUserInitiated && !IsAutomaticTalkCooldownReady())
+                    return;
+
+                // Keep the request queued when generation is temporarily unavailable. This
+                // restores the v1.1 behavior and prevents fast-track requests from being lost.
+                if (TalkService.GenerateTalk(request))
+                {
+                    UserRequestPool.Remove(pawn);
+                    if (!isUserInitiated)
+                        _lastTalkEndTick = GenTicks.TicksGame;
+                }
                 return;
             }
         }
@@ -109,8 +125,7 @@ internal static class TickManagerPatch
             return;
         }
 
-        int intervalTicks = CommonUtil.GetTicksForDuration(TalkInterval);
-        if (intervalTicks > 0 && GenTicks.TicksGame - _lastTalkEndTick >= intervalTicks)
+        if (IsAutomaticTalkCooldownReady())
         {
             // Select a pawn based on the current iteration strategy
             Pawn selectedPawn = PawnSelector.SelectNextAvailablePawn();
@@ -138,6 +153,16 @@ internal static class TickManagerPatch
             
             _lastTalkEndTick = GenTicks.TicksGame;
         }
+    }
+
+    /// <summary>
+    /// Returns whether another automatically generated dialogue may start. Explicit user
+    /// requests intentionally bypass this gate.
+    /// </summary>
+    internal static bool IsAutomaticTalkCooldownReady()
+    {
+        int intervalTicks = CommonUtil.GetTicksForDuration(TalkInterval);
+        return intervalTicks > 0 && GenTicks.TicksGame - _lastTalkEndTick >= intervalTicks;
     }
 
     private static bool TryGenerateTalkFromPool(Pawn pawn)

--- a/Source/Prompt/PromptManager.cs
+++ b/Source/Prompt/PromptManager.cs
@@ -270,6 +270,8 @@ public class PromptManager : IExposable
                     Name = "Context",
                     Role = PromptRole.System,
                     Position = PromptPosition.Relative,
+                    // Dynamic context deliberately follows the stable Base/JSON system entries
+                    // so providers can reuse the longest possible stable prompt prefix.
                     Content = "{{context}}"
                 },
                 // 2. History Section
@@ -390,9 +392,10 @@ public class PromptManager : IExposable
             if (baseEntry != null)
             {
                 originalBaseContent = baseEntry.Content;
-                baseEntry.Content = string.IsNullOrWhiteSpace(settings.SimpleModeInstruction) 
+                string simpleInstruction = string.IsNullOrWhiteSpace(settings.SimpleModeInstruction)
                     ? Constant.DefaultInstruction 
                     : settings.SimpleModeInstruction;
+                baseEntry.Content = Constant.GetSimpleModeInstruction(simpleInstruction);
             }
         }
 

--- a/Source/Service/ContextBuilder.cs
+++ b/Source/Service/ContextBuilder.cs
@@ -414,6 +414,18 @@ public static class ContextBuilder
 
             sb.Append(topicSb).Append(intentSb);
         }
+        else if (talkRequest.IsMonologue && talkRequest.TalkType.IsFromUser())
+        {
+            // A user-directed self talk is still a monologue. Handle it before the generic
+            // user-dialogue branch, which may otherwise prohibit further lines for the speaker.
+            intentSb.Append($"{shortName} monologue");
+            if (!string.IsNullOrWhiteSpace(talkRequest.RawPrompt))
+                topicSb.Append(talkRequest.RawPrompt);
+
+            sb.Append(intentSb);
+            if (topicSb.Length > 0)
+                sb.Append("\n").Append(topicSb);
+        }
         else if (talkRequest.TalkType.IsFromUser())
         {
             var speaker = talkRequest.Recipient ?? (pawns.Count > 1 ? pawns[1] : null);

--- a/Source/Settings/RimTalkSettings.cs
+++ b/Source/Settings/RimTalkSettings.cs
@@ -284,6 +284,30 @@ public class RimTalkSettings : ModSettings
                     baseEntry.Content = Constant.DefaultInstruction;
                     changed = true;
                 }
+
+                // Built-in presets created before this version stored the Simple Mode
+                // monologue limit directly in Base Instruction. Remove it so Advanced Mode
+                // no longer inherits a fixed turn count. User-created presets are untouched.
+                if (baseEntry != null &&
+                    string.Equals(preset.Description, "RimTalk default prompt preset", StringComparison.Ordinal))
+                {
+                    string normalized = Constant.RemoveLegacyMonologueTurnInstruction(baseEntry.Content);
+                    if (!string.Equals(normalized, baseEntry.Content, StringComparison.Ordinal))
+                    {
+                        baseEntry.Content = normalized;
+                        changed = true;
+                    }
+                }
+            }
+
+            // Store Simple Mode's editable instruction without the injected rule. The rule is
+            // appended only to the rendered request by PromptManager.
+            string normalizedSimpleInstruction =
+                Constant.RemoveLegacyMonologueTurnInstruction(SimpleModeInstruction);
+            if (!string.Equals(normalizedSimpleInstruction, SimpleModeInstruction, StringComparison.Ordinal))
+            {
+                SimpleModeInstruction = normalizedSimpleInstruction;
+                changed = true;
             }
 
             if (changed)
@@ -308,7 +332,7 @@ public class RimTalkSettings : ModSettings
             // 2. Migrate from Legacy CustomInstruction
             if (!string.IsNullOrWhiteSpace(CustomInstruction))
             {
-                SimpleModeInstruction = CustomInstruction;
+                SimpleModeInstruction = Constant.RemoveLegacyMonologueTurnInstruction(CustomInstruction);
                 CustomInstruction = "";
             }
         }


### PR DESCRIPTION
## Summary

This PR reports several bugs found in v1.2.0 by players.

## Bug Report

- `TalkInterval` only throttled globally randomized conversations triggered **by the regular tick schedule**r.
- Vanilla interactions intercepted by `BubblePatch` could be fast-tracked and generated without respecting the configured cooldown.
- User-directed monologues could enter the generic user-dialogue branch, preventing multi-turn monologue output even with a custom prompt.
- The default instruction forced monologues to exactly one turn in both Simple and Advanced modes.
- Gemma 3 requests added a random value to the prompt prefix, **potentially reducing prompt-cache hits to zero**.
- Placing dynamic context before stable system instructions also reduces the reusable prompt prefix.

## What’s Changed

- Added a shared automatic-dialogue cooldown check used by both the regular scheduler and fast-track automatic requests.
- Explicit user requests remain exempt from `TalkInterval`.
- Automatic requests no longer interrupt active generation and remain queued if generation cannot start.
- `BubblePatch` now preserves the vanilla bubble instead of enqueueing an AI interaction while the cooldown is active or the AI service is busy.
- Removed the fixed monologue turn count from the general default instruction.
- `Monologue = 1 turn.` is now injected only when rendering prompts in Simple Mode.
- Added migration logic to remove the legacy one-turn restriction from built-in presets while preserving user-created presets.
- User-directed self-talk is now handled as a monologue before the generic user-dialogue branch, allowing Advanced Mode prompts to request multiple monologue turns.
- Removed the random Gemma 3 system-prefix value.
- The default preset keeps stable system content in the following order:
  `Base Instruction → JSON Format → Dynamic Context`.
- Advanced Mode still allows users to fully control preset entry order.

## Warning

This PR is primarily intended to document and report the identified issues while providing minimal candidate fixes. The changes require further in-game testing, especially around interaction frequency, request queue behavior, prompt migration, multi-turn monologues, and provider-side cache performance. Some implementation details may also need additional cleanup or refactoring before the PR is considered production-ready.

PTAL.