### PR TITLE
fix: improve sleep and wake dialogue lifecycle

### DIFF
--- a/Languages/ChineseSimplified/Keyed/Translation_ChineseSimplified.xml
+++ b/Languages/ChineseSimplified/Keyed/Translation_ChineseSimplified.xml
@@ -189,6 +189,8 @@ Scriban 魔法 (动态内容)
     <RimTalk.Settings.AllowCustomConversationTooltip>允许你通过输入台词在角色之间发起自定义对话，或直接与某个角色交谈。右键点击角色即可开始对话。</RimTalk.Settings.AllowCustomConversationTooltip>
     <RimTalk.Settings.ContinueDialogueWhileSleeping>睡觉时继续对话</RimTalk.Settings.ContinueDialogueWhileSleeping>
     <RimTalk.Settings.ContinueDialogueWhileSleepingTooltip>启用后，即使角色入睡，也会继续显示所有生成的对话。</RimTalk.Settings.ContinueDialogueWhileSleepingTooltip>
+    <RimTalk.Settings.EnableSleepDialogue>入睡与醒来对话</RimTalk.Settings.EnableSleepDialogue>
+    <RimTalk.Settings.EnableSleepDialogueTooltip>启用后，殖民者在就寝或醒来时会偶尔发表困倦的言论或独白。</RimTalk.Settings.EnableSleepDialogueTooltip>
 
     <RimTalk.Settings.AllowMonologue>允许独白</RimTalk.Settings.AllowMonologue>
     <RimTalk.Settings.AllowMonologueTooltip>启用后，即使没有其他角色在附近，角色也可能生成 AI 驱动的独白。</RimTalk.Settings.AllowMonologueTooltip>

--- a/Languages/ChineseTraditional/Keyed/Translation_ChineseTraditional.xml
+++ b/Languages/ChineseTraditional/Keyed/Translation_ChineseTraditional.xml
@@ -193,6 +193,8 @@ Scriban 魔法 (動態內容)
     <RimTalk.Settings.AllowCustomConversationTooltip>允許您在角色之間啟動自訂對話，或通過編寫自己的台詞直接與角色交談。右鍵點擊 Pawn 以開始對話。</RimTalk.Settings.AllowCustomConversationTooltip>
     <RimTalk.Settings.ContinueDialogueWhileSleeping>睡覺時繼續對話</RimTalk.Settings.ContinueDialogueWhileSleeping>
     <RimTalk.Settings.ContinueDialogueWhileSleepingTooltip>如果啟用，即使 Pawn 入睡，他們也將繼續說完所有生成的台詞。</RimTalk.Settings.ContinueDialogueWhileSleepingTooltip>
+    <RimTalk.Settings.EnableSleepDialogue>入睡與醒來對話</RimTalk.Settings.EnableSleepDialogue>
+    <RimTalk.Settings.EnableSleepDialogueTooltip>啟用後，殖民者在就寢或醒來時會偶爾發表睏倦的言論或獨白。</RimTalk.Settings.EnableSleepDialogueTooltip>
 
     <RimTalk.Settings.AllowMonologue>允許獨白</RimTalk.Settings.AllowMonologue>
     <RimTalk.Settings.AllowMonologueTooltip>啟用後，即使附近沒有其他 Pawn，Pawn 也可能生成由 AI 驅動的獨白。</RimTalk.Settings.AllowMonologueTooltip>

--- a/Languages/English/Keyed/Translation_English.xml
+++ b/Languages/English/Keyed/Translation_English.xml
@@ -190,6 +190,8 @@ Crucial Tips:
     <RimTalk.Settings.AllowCustomConversationTooltip>Allows you to start custom dialogues between characters or talk directly to a character by writing your own lines. Right-click a pawn to begin a conversation.</RimTalk.Settings.AllowCustomConversationTooltip>
     <RimTalk.Settings.ContinueDialogueWhileSleeping>Continue Dialogue While Sleeping</RimTalk.Settings.ContinueDialogueWhileSleeping>
     <RimTalk.Settings.ContinueDialogueWhileSleepingTooltip>If enabled, pawns will continue speaking all generated lines even if they fall asleep.</RimTalk.Settings.ContinueDialogueWhileSleepingTooltip>
+    <RimTalk.Settings.EnableSleepDialogue>Sleep &amp; Wake Dialogue</RimTalk.Settings.EnableSleepDialogue>
+    <RimTalk.Settings.EnableSleepDialogueTooltip>If enabled, pawns will occasionally initiate sleepy remarks when going to bed or waking up.</RimTalk.Settings.EnableSleepDialogueTooltip>
 
     <RimTalk.Settings.AllowMonologue>Allow Monologues</RimTalk.Settings.AllowMonologue>
     <RimTalk.Settings.AllowMonologueTooltip>When enabled, pawns may generate AI-driven monologues even when no other pawn is nearby.</RimTalk.Settings.AllowMonologueTooltip>

--- a/Languages/French/Keyed/Translation_French.xml
+++ b/Languages/French/Keyed/Translation_French.xml
@@ -193,6 +193,8 @@ Conseils Cruciaux :
     <RimTalk.Settings.AllowCustomConversationTooltip>Permet de lancer des dialogues personnalisés entre personnages ou de parler directement à un personnage en écrivant vos propres répliques. Faites un clic droit sur un colon pour commencer une conversation.</RimTalk.Settings.AllowCustomConversationTooltip>
     <RimTalk.Settings.ContinueDialogueWhileSleeping>Continuer le dialogue pendant le sommeil</RimTalk.Settings.ContinueDialogueWhileSleeping>
     <RimTalk.Settings.ContinueDialogueWhileSleepingTooltip>Si activé, les pions continueront à prononcer toutes les répliques générées même s'ils s'endorment.</RimTalk.Settings.ContinueDialogueWhileSleepingTooltip>
+    <RimTalk.Settings.EnableSleepDialogue>Dialogue de coucher et de réveil</RimTalk.Settings.EnableSleepDialogue>
+    <RimTalk.Settings.EnableSleepDialogueTooltip>Si cette option est activée, les colons émettront occasionnellement de brèves remarques en se couchant ou en se réveillant.</RimTalk.Settings.EnableSleepDialogueTooltip>
 
     <RimTalk.Settings.AllowMonologue>Autoriser les monologues</RimTalk.Settings.AllowMonologue>
     <RimTalk.Settings.AllowMonologueTooltip>Lorsque activé, les personnages peuvent générer des monologues pilotés par l’IA même si aucun autre personnage n’est à proximité.</RimTalk.Settings.AllowMonologueTooltip>

--- a/Languages/Japanese/Keyed/Translation_Japanese.xml
+++ b/Languages/Japanese/Keyed/Translation_Japanese.xml
@@ -193,6 +193,8 @@ Scribanマジック (動的コンテンツ)
     <RimTalk.Settings.AllowCustomConversationTooltip>自分でセリフを入力してキャラクター同士の会話を始めたり、特定のキャラクターと直接話すことができます。対象のキャラクターを右クリックして会話を開始します。</RimTalk.Settings.AllowCustomConversationTooltip>
     <RimTalk.Settings.ContinueDialogueWhileSleeping>睡眠中も会話を続ける</RimTalk.Settings.ContinueDialogueWhileSleeping>
     <RimTalk.Settings.ContinueDialogueWhileSleepingTooltip>有効にすると、ポーンが眠っていても生成されたすべての会話を続けます。</RimTalk.Settings.ContinueDialogueWhileSleepingTooltip>
+    <RimTalk.Settings.EnableSleepDialogue>就寝・起床時の会話</RimTalk.Settings.EnableSleepDialogue>
+    <RimTalk.Settings.EnableSleepDialogueTooltip>有効にすると、ポーンが就寝時や起床時に短い会話やつぶやきを生成します。</RimTalk.Settings.EnableSleepDialogueTooltip>
 
     <RimTalk.Settings.AllowMonologue>独り言を許可</RimTalk.Settings.AllowMonologue>
     <RimTalk.Settings.AllowMonologueTooltip>有効にすると、他のキャラクターが近くにいなくても、キャラクターがAI生成の独り言をする場合があります。</RimTalk.Settings.AllowMonologueTooltip>

--- a/Languages/Korean/Keyed/Translation_Korean.xml
+++ b/Languages/Korean/Keyed/Translation_Korean.xml
@@ -194,6 +194,8 @@ Scriban 매직 (동적 콘텐츠)
     <RimTalk.Settings.AllowCustomConversationTooltip>사용자가 직접 대사를 작성해 캐릭터 간 대화를 시작하거나, 특정 캐릭터와 대화할 수 있습니다. 대화를 시작하려면 원하는 캐릭터를 우클릭하세요.</RimTalk.Settings.AllowCustomConversationTooltip>
     <RimTalk.Settings.ContinueDialogueWhileSleeping>자는 동안 대화 계속</RimTalk.Settings.ContinueDialogueWhileSleeping>
     <RimTalk.Settings.ContinueDialogueWhileSleepingTooltip>활성화하면, 폰이 잠들어도 생성된 모든 대화를 계속 진행합니다.</RimTalk.Settings.ContinueDialogueWhileSleepingTooltip>
+    <RimTalk.Settings.EnableSleepDialogue>수면 및 기상 대화</RimTalk.Settings.EnableSleepDialogue>
+    <RimTalk.Settings.EnableSleepDialogueTooltip>활성화하면, 폰이 잠자리에 들거나 잠에서 깰 때 짧은 대사나 혼잣말을 생성합니다.</RimTalk.Settings.EnableSleepDialogueTooltip>
 
     <RimTalk.Settings.AllowMonologue>독백 허용</RimTalk.Settings.AllowMonologue>
     <RimTalk.Settings.AllowMonologueTooltip>활성화하면 다른 폰이 근처에 없어도 폰이 AI 기반 독백을 생성할 수 있습니다.</RimTalk.Settings.AllowMonologueTooltip>

--- a/Languages/Russian/Keyed/Translation_Russian.xml
+++ b/Languages/Russian/Keyed/Translation_Russian.xml
@@ -192,6 +192,8 @@
     <RimTalk.Settings.AllowCustomConversationTooltip>Позволяет вам начинать собственные диалоги между персонажами или напрямую разговаривать с выбранным персонажем, вводя свои реплики. Щёлкните правой кнопкой мыши по персонажу, чтобы начать разговор.</RimTalk.Settings.AllowCustomConversationTooltip>
     <RimTalk.Settings.ContinueDialogueWhileSleeping>Продолжать диалог во сне</RimTalk.Settings.ContinueDialogueWhileSleeping>
     <RimTalk.Settings.ContinueDialogueWhileSleepingTooltip>Если включено, персонажи будут произносить все сгенерированные реплики, даже если они засыпают.</RimTalk.Settings.ContinueDialogueWhileSleepingTooltip>
+    <RimTalk.Settings.EnableSleepDialogue>Диалоги при отходе ко сну и пробуждении</RimTalk.Settings.EnableSleepDialogue>
+    <RimTalk.Settings.EnableSleepDialogueTooltip>Если включено, поселенцы будут периодически произносить короткие реплики при отходе ко сну или пробуждении.</RimTalk.Settings.EnableSleepDialogueTooltip>
 
     <RimTalk.Settings.AllowMonologue>Разрешить монологи</RimTalk.Settings.AllowMonologue>
     <RimTalk.Settings.AllowMonologueTooltip>Если включено, персонажи могут генерировать монологи на основе ИИ, даже если рядом нет других персонажей.</RimTalk.Settings.AllowMonologueTooltip>

--- a/Source/Data/PawnState.cs
+++ b/Source/Data/PawnState.cs
@@ -40,6 +40,12 @@ public class PawnState(Pawn pawn)
 
     public void AddTalkRequest(string prompt, Pawn recipient, TalkType talkType, string imageBase64)
     {
+        AddTalkRequest(prompt, recipient, talkType, imageBase64, SleepDialogueKind.None);
+    }
+
+    public void AddTalkRequest(string prompt, Pawn recipient, TalkType talkType, string imageBase64,
+        SleepDialogueKind sleepDialogueKind)
+    {
         // Enemies should never receive colony incident, quest, or thought prompts
         if (Pawn.IsEnemy() && talkType is TalkType.Event or TalkType.QuestOffer or TalkType.QuestEnd or TalkType.Thought)
         {
@@ -70,7 +76,8 @@ public class PawnState(Pawn pawn)
         {
             Status = RequestStatus.Pending,
             IsMonologue = recipient == null,
-            ImageBase64 = imageBase64
+            ImageBase64 = imageBase64,
+            SleepDialogueKind = sleepDialogueKind
         };
 
         if (talkType.IsFromUser())

--- a/Source/Data/TalkRequest.cs
+++ b/Source/Data/TalkRequest.cs
@@ -14,6 +14,13 @@ public enum RequestStatus
     Expired
 }
 
+public enum SleepDialogueKind
+{
+    None,
+    Bedtime,
+    WakeUp
+}
+
 public class TalkRequest(string prompt, Pawn initiator, Pawn recipient = null, TalkType talkType = TalkType.Other)
 {
     public TalkType TalkType { get; set; } = talkType;
@@ -31,6 +38,7 @@ public class TalkRequest(string prompt, Pawn initiator, Pawn recipient = null, T
     public bool IsMonologue;
     public bool IsAnnouncement => TalkType == TalkType.Announcement;
     public string ImageBase64 { get; set; }
+    public SleepDialogueKind SleepDialogueKind { get; set; }
     
     /// <summary>
     /// All pawns participating in the dialogue (filled in sync layer)

--- a/Source/Patch/SleepPatch.cs
+++ b/Source/Patch/SleepPatch.cs
@@ -11,25 +11,30 @@ public static class SleepPatch_StartJob
 {
     public static void Prefix(Pawn ___pawn, Job newJob, out (JobDef prevJob, bool wasAsleep) __state)
     {
-        __state = (___pawn?.CurJobDef, ___pawn != null && !___pawn.Awake());
+        JobDef previousJob = ___pawn?.CurJobDef;
+        bool wasAsleep = ___pawn != null && SleepDialogueTracker.IsSleepJob(previousJob) && !___pawn.Awake();
+        __state = (previousJob, wasAsleep);
     }
 
     public static void Postfix(Pawn ___pawn, Job newJob, (JobDef prevJob, bool wasAsleep) __state)
     {
         if (___pawn == null || newJob == null) return;
 
-        bool prevWasSleep = __state.prevJob == JobDefOf.LayDown || __state.prevJob == JobDefOf.Wait_Asleep;
-        bool currIsSleep = newJob.def == JobDefOf.LayDown || newJob.def == JobDefOf.Wait_Asleep;
+        bool prevWasSleep = SleepDialogueTracker.IsSleepJob(__state.prevJob);
+        bool currIsSleep = SleepDialogueTracker.IsSleepJob(newJob.def);
 
         // 1. Started sleeping (transition from non-sleep -> sleep)
         if (!prevWasSleep && currIsSleep)
         {
             SleepDialogueTracker.Notify_GoingToBed(___pawn);
         }
-        // 2. Woke up (transition from sleep -> non-sleep)
+        // 2. Left a sleep job, either by waking normally or for a bedtime interruption.
         else if (prevWasSleep && !currIsSleep)
         {
-            SleepDialogueTracker.Notify_WokeUp(___pawn, __state.wasAsleep);
+            if (SleepDialogueTracker.IsBedtimeInterruptionJob(newJob.def))
+                SleepDialogueTracker.Notify_SleepInterrupted(___pawn);
+            else
+                SleepDialogueTracker.Notify_WokeUp(___pawn, __state.wasAsleep);
         }
     }
 }

--- a/Source/Patch/SleepPatch.cs
+++ b/Source/Patch/SleepPatch.cs
@@ -23,18 +23,23 @@ public static class SleepPatch_StartJob
         bool prevWasSleep = SleepDialogueTracker.IsSleepJob(__state.prevJob);
         bool currIsSleep = SleepDialogueTracker.IsSleepJob(newJob.def);
 
+        // Some relationship jobs end LayDown before starting their own job, so the
+        // sleep-to-job transition is not always direct.
+        if (SleepDialogueTracker.IsBedtimeInterruptionJob(newJob.def))
+        {
+            SleepDialogueTracker.Notify_SleepInterrupted(___pawn);
+            return;
+        }
+
         // 1. Started sleeping (transition from non-sleep -> sleep)
         if (!prevWasSleep && currIsSleep)
         {
             SleepDialogueTracker.Notify_GoingToBed(___pawn);
         }
-        // 2. Left a sleep job, either by waking normally or for a bedtime interruption.
+        // 2. Left a sleep job without entering a recognized bedtime interruption.
         else if (prevWasSleep && !currIsSleep)
         {
-            if (SleepDialogueTracker.IsBedtimeInterruptionJob(newJob.def))
-                SleepDialogueTracker.Notify_SleepInterrupted(___pawn);
-            else
-                SleepDialogueTracker.Notify_WokeUp(___pawn, __state.wasAsleep);
+            SleepDialogueTracker.Notify_WokeUp(___pawn, __state.wasAsleep);
         }
     }
 }

--- a/Source/Service/SleepDialogueTracker.cs
+++ b/Source/Service/SleepDialogueTracker.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using RimTalk.Data;
@@ -14,6 +15,7 @@ namespace RimTalk.Service;
 public static class SleepDialogueTracker
 {
     private const int DailyCooldownTicks = 40000; // ~16 in-game hours (strictly once per daily sleep cycle)
+    private const string RelationshipJobDriverTypeName = "rjw.JobDriver_Sex";
 
     private static readonly Dictionary<int, int> LastBedtimeTicks = new();
     private static readonly Dictionary<int, int> LastWakeUpTicks = new();
@@ -78,6 +80,19 @@ public static class SleepDialogueTracker
         pawnState.AddTalkRequest(prompt, nearbyColonist, TalkType.Sleep, null, SleepDialogueKind.WakeUp);
     }
 
+    public static void Notify_SleepInterrupted(Pawn pawn)
+    {
+        if (pawn == null) return;
+
+        SleepingPawns.Remove(pawn.thingIDNumber);
+
+        var pawnState = Cache.Get(pawn);
+        if (pawnState == null) return;
+
+        ExpirePendingRequests(pawnState, SleepDialogueKind.Bedtime);
+        ExpirePendingRequests(pawnState, SleepDialogueKind.WakeUp);
+    }
+
     public static bool IsGoingToSleep(Pawn pawn)
     {
         if (pawn?.needs?.rest == null) return false;
@@ -86,9 +101,17 @@ public static class SleepDialogueTracker
         return tired || sleepScheduled;
     }
 
-    public static void RefreshRequest(TalkRequest request)
+    public static bool TryRefreshRequest(TalkRequest request)
     {
-        if (request?.TalkType != TalkType.Sleep || request.SleepDialogueKind == SleepDialogueKind.None) return;
+        if (request == null) return false;
+        if (request.TalkType != TalkType.Sleep || request.SleepDialogueKind == SleepDialogueKind.None) return true;
+
+        if (!IsRequestStillValid(request))
+        {
+            TalkRequestPool.AddToHistory(request, RequestStatus.Expired);
+            Cache.Get(request.Initiator)?.TalkRequests.Remove(request);
+            return false;
+        }
 
         var nearbyPawns = PawnSelector.GetNearByTalkablePawns(request.Initiator);
         Pawn partner = nearbyPawns.FirstOrDefault(p => p == request.Recipient && IsValidForSleepDialogue(p))
@@ -99,6 +122,40 @@ public static class SleepDialogueTracker
         request.IsMonologue = partner == null;
         request.Prompt = prompt;
         request.RawPrompt = prompt;
+        return true;
+    }
+
+    public static bool IsSleepJob(JobDef jobDef)
+    {
+        return jobDef == JobDefOf.LayDown || jobDef == JobDefOf.Wait_Asleep;
+    }
+
+    public static bool IsBedtimeInterruptionJob(JobDef jobDef)
+    {
+        if (jobDef == JobDefOf.Lovin) return true;
+
+        for (Type driverType = jobDef?.driverClass; driverType != null; driverType = driverType.BaseType)
+        {
+            if (driverType.FullName == RelationshipJobDriverTypeName)
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool IsRequestStillValid(TalkRequest request)
+    {
+        if (!Settings.Get().EnableSleepDialogue) return false;
+
+        Pawn pawn = request.Initiator;
+        if (!IsValidForSleepDialogue(pawn)) return false;
+
+        return request.SleepDialogueKind switch
+        {
+            SleepDialogueKind.Bedtime => pawn.Awake() && IsSleepJob(pawn.CurJobDef) && IsGoingToSleep(pawn),
+            SleepDialogueKind.WakeUp => pawn.Awake() && !IsSleepJob(pawn.CurJobDef),
+            _ => true
+        };
     }
 
     private static void ExpirePendingRequests(PawnState pawnState, SleepDialogueKind kind)

--- a/Source/Service/SleepDialogueTracker.cs
+++ b/Source/Service/SleepDialogueTracker.cs
@@ -153,7 +153,8 @@ public static class SleepDialogueTracker
         return request.SleepDialogueKind switch
         {
             SleepDialogueKind.Bedtime => pawn.Awake() && IsSleepJob(pawn.CurJobDef) && IsGoingToSleep(pawn),
-            SleepDialogueKind.WakeUp => pawn.Awake() && !IsSleepJob(pawn.CurJobDef),
+            SleepDialogueKind.WakeUp => pawn.Awake() && !IsSleepJob(pawn.CurJobDef)
+                                                     && !IsBedtimeInterruptionJob(pawn.CurJobDef),
             _ => true
         };
     }

--- a/Source/Service/SleepDialogueTracker.cs
+++ b/Source/Service/SleepDialogueTracker.cs
@@ -27,14 +27,15 @@ public static class SleepDialogueTracker
 
         SleepingPawns.Add(pawn.thingIDNumber);
 
+        var pawnState = Cache.Get(pawn);
+        if (pawnState == null) return;
+        ExpirePendingRequests(pawnState, SleepDialogueKind.WakeUp);
+
         int ticks = GenTicks.TicksGame;
         if (LastBedtimeTicks.TryGetValue(pawn.thingIDNumber, out int lastTick) && ticks - lastTick < DailyCooldownTicks)
             return;
 
         LastBedtimeTicks[pawn.thingIDNumber] = ticks;
-
-        var pawnState = Cache.Get(pawn);
-        if (pawnState == null) return;
 
         var nearbyPawns = PawnSelector.GetNearByTalkablePawns(pawn);
         Pawn partner = nearbyPawns.Count > 0 && IsValidForSleepDialogue(nearbyPawns[0]) ? nearbyPawns[0] : null;
@@ -55,6 +56,10 @@ public static class SleepDialogueTracker
         bool wasTrackedSleeping = SleepingPawns.Remove(pawn.thingIDNumber);
         if (!wasTrackedSleeping && !wasAsleep) return;
 
+        var pawnState = Cache.Get(pawn);
+        if (pawnState == null) return;
+        ExpirePendingRequests(pawnState, SleepDialogueKind.Bedtime);
+
         if (!Settings.Get().EnableSleepDialogue) return;
         if (!IsValidForSleepDialogue(pawn)) return;
 
@@ -63,9 +68,6 @@ public static class SleepDialogueTracker
             return;
 
         LastWakeUpTicks[pawn.thingIDNumber] = ticks;
-
-        var pawnState = Cache.Get(pawn);
-        if (pawnState == null) return;
 
         var nearbyPawns = PawnSelector.GetNearByTalkablePawns(pawn);
         Pawn nearbyColonist = nearbyPawns.Count > 0 && IsValidForSleepDialogue(nearbyPawns[0]) ? nearbyPawns[0] : null;
@@ -97,6 +99,22 @@ public static class SleepDialogueTracker
         request.IsMonologue = partner == null;
         request.Prompt = prompt;
         request.RawPrompt = prompt;
+    }
+
+    private static void ExpirePendingRequests(PawnState pawnState, SleepDialogueKind kind)
+    {
+        var node = pawnState.TalkRequests.First;
+        while (node != null)
+        {
+            var next = node.Next;
+            var request = node.Value;
+            if (request.TalkType == TalkType.Sleep && request.SleepDialogueKind == kind)
+            {
+                TalkRequestPool.AddToHistory(request, RequestStatus.Expired);
+                pawnState.TalkRequests.Remove(node);
+            }
+            node = next;
+        }
     }
 
     private static string BuildPrompt(SleepDialogueKind kind, Pawn partner)

--- a/Source/Service/SleepDialogueTracker.cs
+++ b/Source/Service/SleepDialogueTracker.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using RimTalk.Data;
 using RimTalk.Source.Data;
 using RimTalk.Util;
@@ -20,6 +21,7 @@ public static class SleepDialogueTracker
 
     public static void Notify_GoingToBed(Pawn pawn)
     {
+        if (!Settings.Get().EnableSleepDialogue) return;
         if (!IsValidForSleepDialogue(pawn)) return;
         if (!IsGoingToSleep(pawn)) return;
 
@@ -37,16 +39,10 @@ public static class SleepDialogueTracker
         var nearbyPawns = PawnSelector.GetNearByTalkablePawns(pawn);
         Pawn partner = nearbyPawns.Count > 0 && IsValidForSleepDialogue(nearbyPawns[0]) ? nearbyPawns[0] : null;
 
-        string timeStr = GetInGameTimeString(pawn);
-        if (partner != null)
-        {
-            LastBedtimeTicks[partner.thingIDNumber] = ticks;
-            pawnState.AddTalkRequest($"Heading to bed to sleep at {timeStr}, saying a brief sleepy remark to {partner.LabelShort}", partner, TalkType.Sleep);
-        }
-        else
-        {
-            pawnState.AddTalkRequest($"Heading to bed to sleep at {timeStr}, a short sleepy thought before resting", null, TalkType.Sleep);
-        }
+        if (partner != null) LastBedtimeTicks[partner.thingIDNumber] = ticks;
+
+        string prompt = BuildPrompt(SleepDialogueKind.Bedtime, partner);
+        pawnState.AddTalkRequest(prompt, partner, TalkType.Sleep, null, SleepDialogueKind.Bedtime);
     }
 
     public static void Notify_WokeUp(Pawn pawn)
@@ -59,6 +55,7 @@ public static class SleepDialogueTracker
         bool wasTrackedSleeping = SleepingPawns.Remove(pawn.thingIDNumber);
         if (!wasTrackedSleeping && !wasAsleep) return;
 
+        if (!Settings.Get().EnableSleepDialogue) return;
         if (!IsValidForSleepDialogue(pawn)) return;
 
         int ticks = GenTicks.TicksGame;
@@ -73,16 +70,10 @@ public static class SleepDialogueTracker
         var nearbyPawns = PawnSelector.GetNearByTalkablePawns(pawn);
         Pawn nearbyColonist = nearbyPawns.Count > 0 && IsValidForSleepDialogue(nearbyPawns[0]) ? nearbyPawns[0] : null;
 
-        string timeStr = GetInGameTimeString(pawn);
-        if (nearbyColonist != null)
-        {
-            LastWakeUpTicks[nearbyColonist.thingIDNumber] = ticks;
-            pawnState.AddTalkRequest($"Just woke up from sleep at {timeStr}, greeting {nearbyColonist.LabelShort}", nearbyColonist, TalkType.Sleep);
-        }
-        else
-        {
-            pawnState.AddTalkRequest($"Just woke up from sleep at {timeStr}, thinking about rest, mood, or what to do next", null, TalkType.Sleep);
-        }
+        if (nearbyColonist != null) LastWakeUpTicks[nearbyColonist.thingIDNumber] = ticks;
+
+        string prompt = BuildPrompt(SleepDialogueKind.WakeUp, nearbyColonist);
+        pawnState.AddTalkRequest(prompt, nearbyColonist, TalkType.Sleep, null, SleepDialogueKind.WakeUp);
     }
 
     public static bool IsGoingToSleep(Pawn pawn)
@@ -93,15 +84,35 @@ public static class SleepDialogueTracker
         return tired || sleepScheduled;
     }
 
-    private static string GetInGameTimeString(Pawn pawn)
+    public static void RefreshRequest(TalkRequest request)
     {
-        var map = pawn?.Map ?? Find.CurrentMap;
-        if (map != null && Find.WorldGrid != null && Find.TickManager != null)
+        if (request?.TalkType != TalkType.Sleep || request.SleepDialogueKind == SleepDialogueKind.None) return;
+
+        var nearbyPawns = PawnSelector.GetNearByTalkablePawns(request.Initiator);
+        Pawn partner = nearbyPawns.FirstOrDefault(p => p == request.Recipient && IsValidForSleepDialogue(p))
+                       ?? nearbyPawns.FirstOrDefault(IsValidForSleepDialogue);
+
+        string prompt = BuildPrompt(request.SleepDialogueKind, partner);
+        request.Recipient = partner;
+        request.IsMonologue = partner == null;
+        request.Prompt = prompt;
+        request.RawPrompt = prompt;
+    }
+
+    private static string BuildPrompt(SleepDialogueKind kind, Pawn partner)
+    {
+        return kind switch
         {
-            var longLat = Find.WorldGrid.LongLatOf(map.Tile);
-            return CommonUtil.GetInGameHour12HString(Find.TickManager.TicksAbs, longLat);
-        }
-        return CommonUtil.GetInGameData().Hour12HString;
+            SleepDialogueKind.Bedtime when partner != null =>
+                $"Heading to bed, saying a brief sleepy remark to {partner.LabelShort}",
+            SleepDialogueKind.Bedtime =>
+                "Heading to bed, making a brief sleepy remark before resting",
+            SleepDialogueKind.WakeUp when partner != null =>
+                $"Just woke up, greeting {partner.LabelShort} with a brief waking remark",
+            SleepDialogueKind.WakeUp =>
+                "Just woke up, making a brief waking remark about rest, mood, or what to do next",
+            _ => string.Empty
+        };
     }
 
     private static bool IsValidForSleepDialogue(Pawn pawn)

--- a/Source/Service/TalkService.cs
+++ b/Source/Service/TalkService.cs
@@ -31,12 +31,12 @@ public static class TalkService
         if (settings.GetActiveConfig() == null) return false;
         if (AIService.IsBusy()) return false;
 
+        if (!SleepDialogueTracker.TryRefreshRequest(talkRequest)) return false;
+
         PawnState pawn1 = Cache.Get(talkRequest.Initiator);
         if (!talkRequest.TalkType.IsFromUser() && (pawn1 == null || !pawn1.CanGenerateTalk())) return false;
         
         if (!settings.AllowSimultaneousConversations && AnyPawnHasPendingResponses()) return false;
-
-        SleepDialogueTracker.RefreshRequest(talkRequest);
 
         // Ensure the recipient is valid and capable of talking.
         PawnState pawn2 = talkRequest.Recipient != null ? Cache.Get(talkRequest.Recipient) : null;
@@ -84,7 +84,10 @@ public static class TalkService
             foreach (var p in pawns.Where(p => p != null && !p.IsPlayer()))
                 Cache.Get(p)?.IgnoreAllTalkResponses([TalkType.Urgent, TalkType.User, TalkType.Announcement]);
         
-        if (pawns.Count == 1) talkRequest.IsMonologue = true;
+        if (talkRequest.TalkType == TalkType.Sleep)
+            talkRequest.IsMonologue = pawns.Count == 1;
+        else if (pawns.Count == 1)
+            talkRequest.IsMonologue = true;
 
         if (!settings.AllowMonologue && talkRequest.IsMonologue && !talkRequest.TalkType.IsFromUser())
             return false;

--- a/Source/Service/TalkService.cs
+++ b/Source/Service/TalkService.cs
@@ -36,6 +36,8 @@ public static class TalkService
         
         if (!settings.AllowSimultaneousConversations && AnyPawnHasPendingResponses()) return false;
 
+        SleepDialogueTracker.RefreshRequest(talkRequest);
+
         // Ensure the recipient is valid and capable of talking.
         PawnState pawn2 = talkRequest.Recipient != null ? Cache.Get(talkRequest.Recipient) : null;
         if (pawn2 == null || talkRequest.Recipient?.Name == null || !pawn2.CanDisplayTalk())

--- a/Source/Settings/Settings_Basic.cs
+++ b/Source/Settings/Settings_Basic.cs
@@ -125,6 +125,10 @@ public partial class Settings
             ref settings.ContinueDialogueWhileSleeping,
             "RimTalk.Settings.ContinueDialogueWhileSleepingTooltip".Translate().ToString());
         leftListing.Gap(6f);
+        leftListing.CheckboxLabeled("RimTalk.Settings.EnableSleepDialogue".Translate().ToString(),
+            ref settings.EnableSleepDialogue,
+            "RimTalk.Settings.EnableSleepDialogueTooltip".Translate().ToString());
+        leftListing.Gap(6f);
         leftListing.CheckboxLabeled("RimTalk.Settings.ApplyMoodAndSocialEffects".Translate().ToString(),
             ref settings.ApplyMoodAndSocialEffects,
             "RimTalk.Settings.ApplyMoodAndSocialEffectsTooltip".Translate().ToString());

--- a/Source/Util/PawnUtil.cs
+++ b/Source/Util/PawnUtil.cs
@@ -250,9 +250,9 @@ public static class PawnUtil
                 string activity = GetPawnActivity(p, relevantPawns, useOptimization);
                 string talkRequestStr = "";
                 var talkRequest = pawnState.GetNextTalkRequest();
-                if (talkRequest != null && !p.HostileTo(mainPawn))
+                if (talkRequest != null && !p.HostileTo(mainPawn) &&
+                    SleepDialogueTracker.TryRefreshRequest(talkRequest))
                 {
-                    SleepDialogueTracker.RefreshRequest(talkRequest);
                     pawnState.MarkRequestSpoken(talkRequest);
                     talkRequestStr = $" - {talkRequest.Prompt}";
                 }

--- a/Source/Util/PawnUtil.cs
+++ b/Source/Util/PawnUtil.cs
@@ -252,6 +252,7 @@ public static class PawnUtil
                 var talkRequest = pawnState.GetNextTalkRequest();
                 if (talkRequest != null && !p.HostileTo(mainPawn))
                 {
+                    SleepDialogueTracker.RefreshRequest(talkRequest);
                     pawnState.MarkRequestSpoken(talkRequest);
                     talkRequestStr = $" - {talkRequest.Prompt}";
                 }


### PR DESCRIPTION
## Summary

Sleep and wake dialogue captures context when the event occurs, but generation may happen later. By then, pawns may have moved, fallen asleep, changed jobs, or entered a brief bedtime interruption. This could produce stale recipients, outdated sleep lines, or wake dialogue during an activity that should not count as fully waking up.

The saved Sleep & Wake Dialogue setting also remained internally, while its UI and runtime checks had been removed.

## Changed

- Restored the Sleep & Wake Dialogue toggle and its translations.
- Marks managed sleep requests as either bedtime or wake-up requests.
- Revalidates each request immediately before generation or inclusion in nearby dialogue.
- Expires a request when the initiator is no longer in the matching sleep phase, has already fallen asleep, or the feature has been disabled.
- Keeps the original recipient if still nearby.
- Otherwise selects a currently available nearby pawn.
- Falls back to a phase-specific prompt without a named recipient when nobody is nearby:
  - `Heading to bed, making a brief sleepy remark before resting`
  - `Just woke up, making a brief waking remark about rest, mood, or what to do next`
- Keeps the final monologue state consistent with the actual participant list.
- Expires pending wake-up requests when entering bed and pending bedtime requests when waking.
- Treats vanilla Lovin and equivalent relationship activities from a widely used related mod as brief bedtime interruptions, discarding intermediate wake requests instead of treating the transition as a full wake-up.

## Note

RimTalk's normal request already includes the current time through its environment context, so the duplicated event-time text was removed. This prevents the stored event time from conflicting with the time at generation.

Relationship activity is checked only when a pawn actually leaves a sleep job. No polling, periodic scan, or additional queue was introduced.

Queue priority, scheduling, timeout duration, and asynchronous generation remain unchanged. Non-sleep dialogue is unaffected.