### PR TITLE
fix: preserve chronological order in API history

### DIFF
--- a/Source/Data/ApiHistory.cs
+++ b/Source/Data/ApiHistory.cs
@@ -144,9 +144,10 @@ public static class ApiHistory
 
     public static IEnumerable<ApiLog> GetAll()
     {
-        foreach (var log in History)
+        foreach (var id in HistoryOrder)
         {
-            yield return log.Value;
+            if (History.TryGetValue(id, out var log))
+                yield return log;
         }
     }
 


### PR DESCRIPTION
## Summary

The time-based debug view relied on `Dictionary` enumeration order when reading API history.

This initially appeared chronological, but once the history limit was reached and older entries were removed, new entries could reuse internal dictionary slots and appear in the middle of older logs.

## Changed

- Enumerates API logs using the existing `HistoryOrder` list.
- Preserves chronological insertion order after history trimming.
- Safely skips an ID if its corresponding log is no longer present.

## Note

No additional timestamp sorting was introduced. The existing history order is now used as the canonical iteration order.

History limits, trimming, filtering, and log contents remain unchanged.